### PR TITLE
Add a class for zxid

### DIFF
--- a/src/main/java/org/apache/zab/Zxid.java
+++ b/src/main/java/org/apache/zab/Zxid.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Simple implementation of Zxid.
+ */
+public class Zxid implements Comparable<Zxid> {
+  private final int epoch;
+  private final int xid;
+
+  public Zxid(int epoch, int xid) {
+    if (epoch < 0 || xid < 0) {
+      throw new IllegalArgumentException("The epoch and xid can not"
+          + " be negative!");
+    }
+    this.epoch = epoch;
+    this.xid = xid;
+  }
+
+  public int getEpoch() {
+    return this.epoch;
+  }
+
+  public int getXid() {
+    return this.xid;
+  }
+
+  public static Zxid fromByteArray(byte[] bytes) throws IOException {
+    DataInputStream in = new DataInputStream(
+                         new BufferedInputStream(
+                         new ByteArrayInputStream(bytes)));
+    int epoch = in.readInt();
+    int xid = in.readInt();
+    return new Zxid(epoch, xid);
+  }
+
+  /**
+   * Serialize this Zxid into a fixed size (8 bytes) byte array.
+
+   * The resulting byte array can be deserialized with fromByteArray.
+   * @return an array of bytes.
+   * @throws IOException
+   */
+  public byte[] toByteArray() throws IOException {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(new BufferedOutputStream(bout));
+    out.writeInt(this.epoch);
+    out.writeInt(this.xid);
+    out.flush();
+    return bout.toByteArray();
+  }
+
+  // Check whether z1 and z2 are contiguous and z1 precedes z2.
+  public static boolean isContiguous(Zxid z1, Zxid z2) {
+    return z1.epoch == z2.epoch && (z2.xid - z1.xid == 1);
+  }
+
+  @Override
+  public int compareTo(Zxid zxid) {
+    return (this.epoch != zxid.epoch)? this.epoch - zxid.epoch :
+                                       this.xid - zxid.xid;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Zxid [epoch : %s, xid : %s]", this.epoch, this.xid);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    Zxid z = (Zxid)o;
+    return compareTo(z) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 17;
+    hash = hash * 31 + this.epoch;
+    hash = hash * 31 + this.xid;
+    return hash;
+  }
+}

--- a/src/test/java/org/apache/zab/ZxidTest.java
+++ b/src/test/java/org/apache/zab/ZxidTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *  Test Zxid.
+ */
+public class ZxidTest {
+  @Test
+  public void cmpTest() {
+    Zxid z1 = new Zxid(1, 0);
+    Zxid z2 = new Zxid(1, 0);
+    Assert.assertTrue(z1.compareTo(z2) == 0);
+
+    z1 = new Zxid(1, 0);
+    z2 = new Zxid(1, 1);
+    Assert.assertTrue(z1.compareTo(z2) < 0);
+
+    z1 = new Zxid(2, 0);
+    z2 = new Zxid(1, 1);
+    Assert.assertTrue(z1.compareTo(z2) > 0);
+  }
+
+  @Test
+  public void contiguousTest() {
+    Zxid z1 = new Zxid(10, 1);
+    Zxid z2 = new Zxid(10, 2);
+    Assert.assertTrue(Zxid.isContiguous(z1, z2));
+    Assert.assertFalse(Zxid.isContiguous(z2, z1));
+
+    z2 =  new Zxid(10, 3);
+    Assert.assertFalse(Zxid.isContiguous(z1, z2));
+
+    z2 = new Zxid(11, 2);
+    Assert.assertFalse(Zxid.isContiguous(z1, z2));
+  }
+
+  @Test
+  public void serializeTest() throws IOException {
+    Zxid z1 = new Zxid(1, 20);
+    byte[] bytes = z1.toByteArray();
+    Assert.assertEquals(bytes.length, 8);
+    Zxid z2 = Zxid.fromByteArray(bytes);
+    Assert.assertTrue(z1.compareTo(z2) == 0);
+  }
+
+  @Test
+  public void toStringTest() {
+    Zxid z = new Zxid(10, 3);
+    Assert.assertEquals("Zxid [epoch : 10, xid : 3]", z.toString());
+  }
+}


### PR DESCRIPTION
Initially we'll use 4 bytes for epoch and 4 bytes for xid (see gh-2).
- It needs to be comparable.
- toByteArray / fromByteArray to serialize / deserialize. The byte array must be fixed size.
- Do we need to be able to check if 2 zxids are contiguous to make sure there is no gap?
