### PR TITLE
Define the client facing interface to ZAB

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -144,7 +144,6 @@
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
-    <module name="VisibilityModifier"/>
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->

--- a/src/main/java/org/apache/zab/StateMachine.java
+++ b/src/main/java/org/apache/zab/StateMachine.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * The state machine interface. It contains a list
+ * of callbacks which will be called by Zab. It
+ * should be implemented by user.
+ */
+public interface StateMachine {
+  /**
+   * This method is called only on the leader after
+   * the Zxid has been assigned but before proposing
+   * the message to followers.
+   *
+   * @param zxid zxid of the message.
+   * @param message the original message
+   * @return an idempotent state update based on
+   * the original message. This is what gets proposed
+   * to followers.
+   */
+  byte[] preprocess(Zxid zxid, byte[] message);
+
+  /**
+   * Called after the state update has been committed.
+   * This method is called from a single thread to ensure
+   * that the state updates are applied in the same order
+   * they arrived.
+   *
+   * @param zxid zxid of the message
+   * @param stateUpdate the incremental state update
+   */
+  void deliver(Zxid zxid, byte[] stateUpdate);
+
+  /**
+   * Serializes state of the application to OutputStream.
+   * Once this callback is called. The user should write
+   * the state of their application to os. This can be
+   * called from a different thread of the that calls deliver
+   * to avoid blocking the delivery of the message.
+   *
+   * @param os the output stream
+   */
+  void getState(OutputStream os);
+
+  /**
+   * Deserializes the state of the application from the
+   * IputStream. Once this callback is called. The user
+   * could restore their application state from the input
+   * stream. This can be only called from the same thread of
+   * the one calls deliver to avoid ending up in inconsistent
+   * state.
+   *
+   * @param is the input stream
+   */
+  void setState(InputStream is);
+}

--- a/src/main/java/org/apache/zab/Zab.java
+++ b/src/main/java/org/apache/zab/Zab.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.IOException;
+
+/**
+ * Abstract class for Zab implementation.
+ */
+public abstract class Zab {
+  protected StateMachine stateMachine;
+
+  /**
+   * Constructs the Zab object.
+   *
+   * @param st the state machine interface
+   */
+  public Zab(StateMachine st) {
+    this.stateMachine = st;
+  }
+
+  /**
+   * Sends a message to Zab. Any one can call call this
+   * interface. Under the hood, followers forward requests
+   * to the leader and the leader will be responsible for
+   * broadcasting.
+   *
+   * @param message
+   * @throws IOException in case of IO failures
+   */
+  public abstract void send(byte[] message) throws IOException;
+
+  /**
+   * Trims a prefix of the log. Used to reduce the size
+   * of log after snapshot.
+   *
+   * @param zxid trim the log to zxid(including zxid)
+   */
+  public abstract void trimLogTo(Zxid zxid);
+
+  /**
+   * Redelivers all txns starting from zxid.
+   *
+   * @param zxid the first transaction id to replay
+   * from
+   * @throws IOException in case of IO failures
+   */
+  public abstract void replayLogFrom(Zxid zxid) throws IOException;
+}


### PR DESCRIPTION
Define the interface that will be used by the client to interact with ZAB. ZOOKEEPER-30 defines the interface pretty nicely, so we can use that as a reference.

https://issues.apache.org/jira/browse/ZOOKEEPER-30

It might look something like this:

```
// all the callback methods are invoked by a single thread.
interface ZabCallback {
    // called after the message has been committed.
    void deliver(Zxid zxid, byte[] message, Object context);

    // called when the server state (looking/following/leading) changes
    void serverStateChanged(state newState, string leaderServerId);
}

abstract class Zab {
    Zab(ZabCallback callback) {
        this.callback = callback;
    }

    // send a message. This method returns immediately after enqueuing
    // the message. context is an optional parameter (could be null) that
    // will be passed back in the deliver callback. 
    void send(byte[] message, Object context);
}
```
