### PR TITLE
Implement a single node Zab

### DIFF
--- a/src/main/java/org/apache/zab/Log.java
+++ b/src/main/java/org/apache/zab/Log.java
@@ -47,7 +47,7 @@ public interface Log extends AutoCloseable {
    * Gets the latest transaction id from log.
    *
    * @return the transaction id of the latest transaction.
-   * Return Zxid.INVALID_ZXID if the log is empty.
+   * Return Zxid.ZXID_NOT_EXIST if the log is empty.
    * @throws IOException in case of IO failures
    */
   Zxid getLatestZxid() throws IOException;

--- a/src/main/java/org/apache/zab/SimpleLog.java
+++ b/src/main/java/org/apache/zab/SimpleLog.java
@@ -147,7 +147,7 @@ public class SimpleLog implements Log {
    * Gets the latest appended transaction id from the log.
    *
    * @return the transaction id of the latest transaction.
-   * or Zxid.INVALID_ZXID if the log is empty.
+   * or Zxid.ZXID_NOT_EXIST if the log is empty.
    * @throws IOException in case of IO failure
    */
   @Override
@@ -159,7 +159,7 @@ public class SimpleLog implements Log {
         txn = iter.next();
       }
       if(txn == null) {
-        return Zxid.INVALID_ZXID;
+        return Zxid.ZXID_NOT_EXIST;
       }
       return txn.getZxid();
     } finally {

--- a/src/main/java/org/apache/zab/SingleNodeZab.java
+++ b/src/main/java/org/apache/zab/SingleNodeZab.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.IOException;
+import java.io.File;
+import java.nio.ByteBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The implementation of single node Zab. There's
+ * no leader election and network message for this
+ * implementation. It's used for implementing some
+ * referencing applications without waiting for the
+ * fully functional Zab.
+ */
+public class SingleNodeZab extends Zab {
+  private final Log txnLog;
+  // Last proposed transaction
+  private Zxid lastProposedZxid;
+
+  static final Logger LOG = LoggerFactory.getLogger(SingleNodeZab.class);
+
+  /**
+   * Construct the single node zab.
+   *
+   * @param st the implementation of StateMachine interface.
+   * @param dir the directory of logs
+   * @throws IOException in case of IO failure
+   */
+  public SingleNodeZab(StateMachine st, String dir) throws IOException {
+    super(st);
+    this.txnLog = new SimpleLog(new File(dir, "transaction.log"));
+    try {
+      this.lastProposedZxid = txnLog.getLatestZxid();
+      // If the lastProposedZxid is not Zxid.ZXID_NOT_EXIST, it means the
+      // log file is not empty. Replay all the transactions in the log.
+      if (this.lastProposedZxid.compareTo(Zxid.ZXID_NOT_EXIST) != 0) {
+        this.replayLogFrom(new Zxid(0, 0));
+      }
+    } catch(IOException e) {
+      LOG.error("Failed to replay transaction.log from Zxid 0:0", e);
+      txnLog.close();
+      throw e;
+    }
+  }
+
+  /**
+   * Sends a message to Zab. The single node Zab simply call
+   * preprocess to get state update then call deliver.
+   *
+   * @param message message to send through Zab
+   * @throws IOException in case of IO failures
+   */
+  @Override
+  public void send(ByteBuffer message) throws IOException {
+    Zxid zxid = new Zxid(this.lastProposedZxid.getEpoch(),
+                         this.lastProposedZxid.getXid() + 1);
+    // Updates last proposed transaction id.
+    this.lastProposedZxid = zxid;
+    // Converts the message to state update.
+    ByteBuffer stateUpdate = this.stateMachine.preprocess(zxid, message);
+    // Appends it to transaction log.
+    this.txnLog.append(new Transaction(zxid, stateUpdate.asReadOnlyBuffer()));
+    // Sync log to physical media.
+    this.txnLog.sync();
+    // Delivers the state update.
+    this.stateMachine.deliver(zxid, stateUpdate);
+  }
+
+  /**
+   * Trims a prefix of the log. Used to reduce the size
+   * of log after snapshot. It's not implemented in this version.
+   *
+   * @param zxid trim the log to zxid(including zxid)
+   */
+  @Override
+  public void trimLogTo(Zxid zxid) {
+    throw new UnsupportedOperationException("Now the log doesn't support "
+        + "trim operation");
+  }
+
+  /**
+   * Redelivers all txns starting from zxid.
+   *
+   * @param zxid the first transaction id to replay from.
+   * @throws IOException in case of IO failures
+   */
+  @Override
+  public void replayLogFrom(Zxid zxid) throws IOException {
+    try (Log.LogIterator iter = this.txnLog.getIterator(zxid)) {
+      while (iter.hasNext()) {
+        Transaction txn = iter.next();
+        this.stateMachine.deliver(txn.getZxid(), txn.getBody());
+      }
+    }
+  }
+}

--- a/src/main/java/org/apache/zab/StateMachine.java
+++ b/src/main/java/org/apache/zab/StateMachine.java
@@ -20,6 +20,7 @@ package org.apache.zab;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 /**
  * The state machine interface. It contains a list
@@ -38,7 +39,7 @@ public interface StateMachine {
    * the original message. This is what gets proposed
    * to followers.
    */
-  byte[] preprocess(Zxid zxid, byte[] message);
+  ByteBuffer preprocess(Zxid zxid, ByteBuffer message);
 
   /**
    * Called after the state update has been committed.
@@ -49,7 +50,7 @@ public interface StateMachine {
    * @param zxid zxid of the message
    * @param stateUpdate the incremental state update
    */
-  void deliver(Zxid zxid, byte[] stateUpdate);
+  void deliver(Zxid zxid, ByteBuffer stateUpdate);
 
   /**
    * Serializes state of the application to OutputStream.

--- a/src/main/java/org/apache/zab/Zab.java
+++ b/src/main/java/org/apache/zab/Zab.java
@@ -19,11 +19,19 @@
 package org.apache.zab;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * Abstract class for Zab implementation.
  */
 public abstract class Zab {
+  protected StateMachine stateMachine;
+
+  // Construct Zab with a StateMachine interface.
+  public Zab(StateMachine stateMachine) {
+    this.stateMachine = stateMachine;
+  }
+
   /**
    * Sends a message to Zab. Any one can call call this
    * interface. Under the hood, followers forward requests
@@ -33,7 +41,7 @@ public abstract class Zab {
    * @param message message to send through Zab
    * @throws IOException in case of IO failures
    */
-  public abstract void send(byte[] message) throws IOException;
+  public abstract void send(ByteBuffer message) throws IOException;
 
   /**
    * Trims a prefix of the log. Used to reduce the size

--- a/src/main/java/org/apache/zab/Zxid.java
+++ b/src/main/java/org/apache/zab/Zxid.java
@@ -33,11 +33,11 @@ public class Zxid implements Comparable<Zxid> {
   private final int epoch;
   private final int xid;
   private static final int ZXID_LENGTH = 8;
-  static final Zxid INVALID_ZXID = new Zxid();
+  static final Zxid ZXID_NOT_EXIST = new Zxid();
 
   private Zxid() {
-    this.epoch = -1;
-    this.xid = 0;
+    this.epoch = 0;
+    this.xid = -1;
   }
 
   public Zxid(int epoch, int xid) {

--- a/src/test/java/org/apache/zab/SingleNodeZabTest.java
+++ b/src/test/java/org/apache/zab/SingleNodeZabTest.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zab;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Dummy StateMachine implementation. Used for test only.
+ */
+class TestStateMachine implements StateMachine {
+  ArrayList<ByteBuffer> deliveredTxns = new ArrayList<ByteBuffer>();
+
+  @Override
+  public ByteBuffer preprocess(Zxid zxid, ByteBuffer message) {
+    // Just return the message without any processing.
+    return message;
+  }
+
+  @Override
+  public void deliver(Zxid zxid, ByteBuffer stateUpdate) {
+    // Add the delivered message to list.
+    this.deliveredTxns.add(stateUpdate);
+  }
+
+  @Override
+  public void getState(OutputStream os) {
+    throw new UnsupportedOperationException("This implementation"
+        + "doesn't support getState operation");
+  }
+
+  @Override
+  public void setState(InputStream is) {
+    throw new UnsupportedOperationException("This implementation"
+        + "doesn't support setState operation");
+  }
+}
+
+/**
+ * Test on single node Zab implementation.
+ */
+public class SingleNodeZabTest extends TestBase {
+  private SingleNodeZab zab;
+  private TestStateMachine sm;
+  private File logDir;
+
+  /**
+   * Test setup.
+   *
+   * @throws IOException
+   */
+  @Before
+  public void setUp() throws IOException {
+    File rootDir = new File("target/log");
+    this.logDir = new File(rootDir, this.testName.getMethodName());
+    File logFile = new File(this.logDir, "transaction.log");
+    // If root dir doesn't exist, create it.
+    if (!rootDir.exists()) {
+      rootDir.mkdir();
+    }
+    // Delete previous log file, if any.
+    if (logFile.exists()) {
+      logFile.delete();
+    }
+    this.logDir.mkdir();
+    this.sm = new TestStateMachine();
+    this.zab = new SingleNodeZab(this.sm, this.logDir.getCanonicalPath());
+  }
+
+  /**
+   * Test if the messages are delivered.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testDelivery() throws IOException {
+    this.zab.send(ByteBuffer.wrap("message 0".getBytes()));
+    this.zab.send(ByteBuffer.wrap("message 1".getBytes()));
+    this.zab.send(ByteBuffer.wrap("message 2".getBytes()));
+    this.zab.send(ByteBuffer.wrap("message 3".getBytes()));
+    // Make sure there're 4 messages delivered.
+    Assert.assertEquals(this.sm.deliveredTxns.size(), 4);
+    // Assert first message is correct.
+    Assert.assertTrue(this.sm.deliveredTxns.get(0)
+                      .equals(ByteBuffer.wrap("message 0".getBytes())));
+    // Assert second message is correct.
+    Assert.assertTrue(this.sm.deliveredTxns.get(1)
+                      .equals(ByteBuffer.wrap("message 1".getBytes())));
+    // Assert third message is correct.
+    Assert.assertTrue(this.sm.deliveredTxns.get(2)
+                      .equals(ByteBuffer.wrap("message 2".getBytes())));
+    // Assert fourth message is correct.
+    Assert.assertTrue(this.sm.deliveredTxns.get(3)
+                      .equals(ByteBuffer.wrap("message 3".getBytes())));
+  }
+
+  /**
+   * Test if the transactions are replayed.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testReplayLog() throws IOException {
+    this.zab.send(ByteBuffer.wrap("message 0".getBytes()));
+    this.zab.send(ByteBuffer.wrap("message 1".getBytes()));
+    // Replay from second transaction.
+    this.zab.replayLogFrom(new Zxid(0, 1));
+    // After replay, there should have 3 delivered messages in list.
+    Assert.assertEquals(this.sm.deliveredTxns.size(), 3);
+    // First message should be "message 0"
+    Assert.assertTrue(this.sm.deliveredTxns.get(0)
+                      .equals(ByteBuffer.wrap("message 0".getBytes())));
+    // The last two messages should be identical.
+    Assert.assertTrue(this.sm.deliveredTxns.get(1)
+                      .equals(ByteBuffer.wrap("message 1".getBytes())));
+    Assert.assertTrue(this.sm.deliveredTxns.get(2)
+                      .equals(ByteBuffer.wrap("message 1".getBytes())));
+  }
+
+  /**
+   * Test if the transaction is replayed after recovery.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testRecovery() throws IOException {
+    this.zab.send(ByteBuffer.wrap("message 0".getBytes()));
+    this.zab.send(ByteBuffer.wrap("message 1".getBytes()));
+
+    // Simulate crash. Restart.
+    this.sm = new TestStateMachine();
+    // Recover from log file.
+    this.zab = new SingleNodeZab(this.sm, this.logDir.getCanonicalPath());
+    // After recovery, there should have 2 delivered messages in list.
+    Assert.assertEquals(this.sm.deliveredTxns.size(), 2);
+    // Assert that the redelivered messages are correct.
+    Assert.assertTrue(this.sm.deliveredTxns.get(0)
+                      .equals(ByteBuffer.wrap("message 0".getBytes())));
+    Assert.assertTrue(this.sm.deliveredTxns.get(1)
+                      .equals(ByteBuffer.wrap("message 1".getBytes())));
+  }
+}

--- a/src/test/java/org/apache/zab/TestBase.java
+++ b/src/test/java/org/apache/zab/TestBase.java
@@ -19,6 +19,7 @@
 package org.apache.zab;
 
 import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
@@ -29,6 +30,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TestBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestBase.class);
+
+  @Rule public TestName testName = new TestName();
 
   /**
    * Logs the beginning and the end of the each test method.


### PR DESCRIPTION
Once #2 and #11 are done, implement a single node Zab (i.e. no leader election / no quorum packets). I think this is useful because we can start implementing a reference application against the single node zab without waiting for the fully functional zab.
