### PR TITLE
Define messages (using protobuf?)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,30 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-sources</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <tasks>
+                <mkdir dir="target/generated-sources"/>
+                <exec executable="protoc">
+                  <arg value="--java_out=target/generated-sources"/>
+                  <arg value="src/main/resources/zab_message.proto"/>
+                </exec>
+              </tasks>
+              <sourceRoot>target/generated-sources</sourceRoot>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+    
   </build>
   <dependencies>
     <dependency>
@@ -160,6 +183,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.1.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>com.google.protobuf</groupId>
+    	<artifactId>protobuf-java</artifactId>
+    	<version>2.5.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/resources/zab_message.proto
+++ b/src/main/resources/zab_message.proto
@@ -1,0 +1,48 @@
+package zab;
+
+option java_package = "org.apache.zab.proto";
+option java_outer_classname = "ZabMessage";
+
+message Message {
+  enum MessageType {
+    HEARTBEAT = 0;
+    // Corresponds to CEPOCH message in Zab paper.
+    PROPOSED_EPOCH = 1;
+    NEW_EPOCH = 2;
+    ACK_EPOCH = 3;
+    NEW_LEADER = 4;
+    ACK_LEADER = 5;
+    COMMIT_LEADER = 6;
+    PROPOSE = 7;
+    ACK = 8;
+    COMMIT = 9;
+  }
+
+  required MessageType type = 1;
+
+  // One of the following will be filled in depending on the message type. If
+  // the message type is heartbeat message, then none of the following will be
+  // filled in.
+  optional ProposedEpoch proposed_epoch = 2;
+  optional NewEpoch new_epoch = 3;
+  optional AckEpoch ack_epoch = 4;
+}
+
+// This message corresponds to CEPOCH message in Zab paper.
+message ProposedEpoch {
+  required int32 proposed_epoch = 1;
+}
+
+message NewEpoch {
+  required int32 new_epoch = 1;
+}
+
+message AckEpoch {
+  required int32 acknowledged_epoch = 1;
+  required Zxid lastZxid = 2;
+}
+
+message Zxid {
+  required int32 epoch = 1;
+  required int32 xid = 2;
+}


### PR DESCRIPTION
Define messages based on https://cwiki.apache.org/confluence/display/ZOOKEEPER/Zab+in+words . I'm assuming we'll use protobuf, but let me know if anybody has other suggestions for serialization framework. We probably won't implement observer in v0.1, and there is no snapshot.

```
enum message {
    followerinfo,
    diff,
    trunc,
    leaderinfo,
    ackepoch,
    newleader,
    uptodate,
    proposal,
    ack,
    commit,
}

struct followerinfo {
    int? acceptedepoch,
    int protocolversion,
    int serverid,
}

struct diff {
    long? zxid
}

struct trunc {
    long? zxid
}

struct leaderinfo {
    int? proposedepoch
    // What is 'protocol' in the data field?
}

struct ackepoch {
    long? lastZxid
    int? currentEpoch
}

struct newleader {
    int? epoch
}

struct uptodate {
}

struct proposal {
    long zxid
    byte[] message
}

struct ack {
    long? zxid
}

struct commit {
    long? zxid
}
```

A few questions:
- What's the protocol field in the leaderinfo packet?
- Should the zxid be 8 byte epoch + 8 byte xid, or 4 byte epoch + 4 byte xid?
- Is there a better way to handle server IDs, like using hostname + port to identify servers? I'm not a big fan of the myid files. Using myid files does have one big advantage that the conf files are uniform across all the servers though.
