### PR TITLE
use 'request of death' to shut down processors

### DIFF
--- a/src/main/java/org/apache/zab/AckProcessor.java
+++ b/src/main/java/org/apache/zab/AckProcessor.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -68,6 +69,11 @@ public class AckProcessor implements RequestProcessor,
     try {
       while (true) {
         Request request = ackQueue.take();
+
+        if (request == Request.REQ_DEAD) {
+          break;
+        }
+
         String source = request.getServerId();
         ZabMessage.Ack ack = request.getMessage().getAck();
         Zxid zxid = MessageBuilder.fromProtoZxid(ack.getZxid());
@@ -94,11 +100,13 @@ public class AckProcessor implements RequestProcessor,
       LOG.error("Caught exception in AckProcessor!", e);
       throw e;
     }
+    LOG.debug("AckProcesser has been shut down.");
+    return null;
   }
 
   @Override
-  public void shutdown() {
-    this.ft.cancel(true);
-    LOG.debug("AckProcesser has been shut down.");
+  public void shutdown() throws InterruptedException, ExecutionException {
+    this.ackQueue.add(Request.REQ_DEAD);
+    this.ft.get();
   }
 }

--- a/src/main/java/org/apache/zab/PreProcessor.java
+++ b/src/main/java/org/apache/zab/PreProcessor.java
@@ -21,11 +21,11 @@ package org.apache.zab;
 import java.nio.ByteBuffer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Map;
-
 import org.apache.zab.proto.ZabMessage;
 import org.apache.zab.proto.ZabMessage.Message;
 import org.slf4j.Logger;
@@ -75,6 +75,11 @@ public class PreProcessor implements RequestProcessor,
     try {
       while (true) {
         Request request = this.requestQueue.take();
+
+        if (request == Request.REQ_DEAD) {
+          break;
+        }
+
         ZabMessage.Request req = request.getMessage().getRequest();
         ByteBuffer bufReq = ByteBuffer.wrap(req.toByteArray());
         // Invoke the callback to convert the request into transaction.
@@ -94,12 +99,14 @@ public class PreProcessor implements RequestProcessor,
       LOG.error("Caught exception in PreProcessor!", e);
       throw e;
     }
+    LOG.debug("PreProcessor has been shut down.");
+    return null;
   }
 
   @Override
-  public void shutdown() {
-    this.ft.cancel(true);
-    LOG.debug("PreProcessor has been shut down.");
+  public void shutdown() throws InterruptedException, ExecutionException {
+    this.requestQueue.add(Request.REQ_DEAD);
+    this.ft.get();
   }
 }
 

--- a/src/main/java/org/apache/zab/Request.java
+++ b/src/main/java/org/apache/zab/Request.java
@@ -27,6 +27,8 @@ public class Request {
   private final String serverId;
   private final Message message;
 
+  public static final Request REQ_DEAD = new Request(null, null);
+
   public Request(String serverId, Message message) {
     this.serverId = serverId;
     this.message = message;

--- a/src/main/java/org/apache/zab/RequestProcessor.java
+++ b/src/main/java/org/apache/zab/RequestProcessor.java
@@ -18,6 +18,8 @@
 
 package org.apache.zab;
 
+import java.util.concurrent.ExecutionException;
+
 /**
  * Interface for request processor. Different processors are chained together
  * to process request in order.
@@ -35,6 +37,8 @@ public interface RequestProcessor {
 
   /**
    * Shutdown the processor.
+   * @throws ExecutionException
+   * @throws InterruptedException
    */
-  void shutdown();
+  void shutdown() throws InterruptedException, ExecutionException;
 }

--- a/src/main/java/org/apache/zab/SyncProposalProcessor.java
+++ b/src/main/java/org/apache/zab/SyncProposalProcessor.java
@@ -21,6 +21,7 @@ package org.apache.zab;
 import java.nio.ByteBuffer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -78,6 +79,11 @@ public class SyncProposalProcessor implements RequestProcessor,
     try {
       while (true) {
         Request request = this.proposalQueue.take();
+
+        if (request == Request.REQ_DEAD) {
+          break;
+        }
+
         Transaction txn = MessageBuilder
                           .fromProposal(request.getMessage().getProposal());
         LOG.debug("Syncing transaction {} to disk.", txn);
@@ -89,12 +95,13 @@ public class SyncProposalProcessor implements RequestProcessor,
       LOG.error("Caught exception in SyncProposalProcessor!");
       throw e;
     }
+    LOG.debug("SyncProposalProcessor has been shut down.");
+    return null;
   }
 
   @Override
-  public void shutdown() {
-    this.ft.cancel(true);
-    LOG.debug("SyncProposalProcessor has been shut down.");
+  public void shutdown() throws InterruptedException, ExecutionException {
+    this.proposalQueue.add(Request.REQ_DEAD);
+    this.ft.get();
   }
-
 }


### PR DESCRIPTION
@EasonLiao sorry I keep going back and forth on this, but I think we should enqueue a special message to tell the processor to get out of the loop instead of using the interrupt. Interrupts are a bit tricky to handle because the thread might not be blocked when you call interrupt, and you need to check the status using isInterrupted().
