### PR TITLE
Add zab state callback (LOOKING/LEADING/FOLLOWING)

### DIFF
--- a/src/main/java/org/apache/zab/StateMachine.java
+++ b/src/main/java/org/apache/zab/StateMachine.java
@@ -74,4 +74,15 @@ public interface StateMachine {
    * @param is the input stream
    */
   void setState(InputStream is);
+
+  /**
+   * Upcall to notify the state of Zab is changed. The state of Zab
+   * is important to applications. Applications should only send request
+   * to Zab or serve requests from clients when Zab is in LEADING/FOLLOWING
+   * state.
+   *
+   * @param state the current state of Zab, it could be
+   * LOOING/FOLLOWING/LEADING.
+   */
+  void stateChanged(Zab.ZabState state);
 }

--- a/src/main/java/org/apache/zab/Zab.java
+++ b/src/main/java/org/apache/zab/Zab.java
@@ -30,6 +30,15 @@ public abstract class Zab {
   protected ZabConfig config;
 
   /**
+   * The state of the Zab.
+   */
+  public enum ZabState {
+    LOOKING,
+    LEADING,
+    FOLLOWING
+  }
+
+  /**
    * Constructs an Zab object.
    *
    * @param stateMachine the state machine implementation

--- a/src/test/java/org/apache/zab/TestStateMachine.java
+++ b/src/test/java/org/apache/zab/TestStateMachine.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import org.apache.zab.Zab.ZabState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,5 +75,9 @@ class TestStateMachine implements StateMachine {
   public void setState(InputStream is) {
     throw new UnsupportedOperationException("This implementation"
         + "doesn't support setState operation");
+  }
+
+  @Override
+  public void stateChanged(ZabState state) {
   }
 }


### PR DESCRIPTION
@fpj  @fengjingchao  Last week michi discussed this with me. Here I open the issue to bring everyone to same page and ask for suggestions.

Our current StateMachine interface looks like : 

```
public interface StateMachine {
  ...
  ByteBuffer preprocess(Zxid zxid, ByteBuffer message);
  ...
}
```

The client's preprocess callback will be called to convert the requests to idempotent transactions. Clients will convert requests to transactions based on their current application state. Since Zab allows multiple outgoing transactions at same time, the clients' current application state can't reflect all the changes made by clients, there may be some pending transactions which are not applied yet. So we may modify the interface to something like : 

```
public interface StateMachine {
  ...
  ByteBuffer preprocess(Zxid zxid, ByteBuffer message, List<ByteBuffer> pendingTxns);
  ...
}
```

It seems ZK does the same thing, as michi pointed out in #56 .

I think this interface is fine, but it's not very user friendly. Please let us know if you have any suggestions. Thanks!
