### PR TITLE
Add radomized sleep to break round-robin loop

### DIFF
--- a/src/main/java/org/apache/zab/RoundRobinElection.java
+++ b/src/main/java/org/apache/zab/RoundRobinElection.java
@@ -40,6 +40,12 @@ public class RoundRobinElection implements Election {
       // Reset round to zero once change to a new epoch.
       this.round = 0;
       this.lastEpoch = state.getProposedEpoch();
+    } else {
+      try {
+        Thread.sleep((long)(Math.random() * 500));
+      } catch(InterruptedException e) {
+        LOG.debug("Interrupted exception in RoundRobinElection.");
+      }
     }
     int idx = this.round % state.getEnsembleSize();
     cb.leaderElected(state.getServerList().get(idx));


### PR DESCRIPTION
It takes a long time for the leader election to settle depending on the timing the servers get started. We need to add a randomized delay to break the loop. I think the easiest thing to do is to add randomized sleep (maybe something like 0 ~ 500ms?)  in RoundRobinElection.initialize() except for the first round for each epoch.
