### PR TITLE
ack processor doesn't need to send commit for already committed transactions

### DIFF
--- a/src/main/java/org/apache/zab/Participant.java
+++ b/src/main/java/org/apache/zab/Participant.java
@@ -222,7 +222,6 @@ public class Participant implements Callable<Void>,
       // It's FOLLOWING, sends to leader directly.
       LOG.debug("It's FOLLOWING state. Forwards the request to leader.");
       Message msg = MessageBuilder.buildRequest(request);
-      MessageTuple tuple = new MessageTuple(this.config.getServerId(), msg);
       // Forwards REQUEST to the leader.
       sendMessage(this.electedLeader, msg);
     }
@@ -938,6 +937,7 @@ public class Participant implements Callable<Void>,
     LOG.debug("Waiting for synchronization to followers complete.");
 
     int completeCount = 0;
+    Zxid lastZxid = this.log.getLatestZxid();
 
     while (completeCount < this.quorumSet.size()) {
       MessageTuple tuple = getExpectedMessage(MessageType.ACK, null);
@@ -945,7 +945,7 @@ public class Participant implements Callable<Void>,
       String source =tuple.getSource();
       Zxid zxid = MessageBuilder.fromProtoZxid(ack.getZxid());
 
-      if (zxid.compareTo(this.log.getLatestZxid()) != 0) {
+      if (zxid.compareTo(lastZxid) != 0) {
         LOG.error("The follower {} is not correctly synchronized.", source);
         throw new RuntimeException("The synchronized follower's last zxid"
             + "doesn't match last zxid of current leader.");
@@ -954,7 +954,9 @@ public class Participant implements Callable<Void>,
         LOG.warn("Quorum set doesn't contain {}, a bug?", source);
         continue;
       }
-      this.quorumSet.get(source).setLastAckedZxid(zxid);
+      PeerHandler ph = this.quorumSet.get(source);
+      ph.setLastAckedZxid(zxid);
+      ph.setLastCommittedZxid(zxid);
       completeCount++;
     }
   }
@@ -1009,6 +1011,7 @@ public class Participant implements Callable<Void>,
                                      scTransport,
                                      this.config.getTimeout() / 3);
     lh.setLastAckedZxid(lastZxid);
+    lh.setLastCommittedZxid(lastZxid);
     lh.setFuture(es.submit(lh));
     this.quorumSet.put(this.config.getServerId(), lh);
 

--- a/src/main/java/org/apache/zab/PeerHandler.java
+++ b/src/main/java/org/apache/zab/PeerHandler.java
@@ -98,6 +98,12 @@ public class PeerHandler implements Callable<Void> {
    */
   protected final int heartbeatIntervalMs;
 
+  /**
+   * The last zxid of COMMIT message sent to the peer. Used to avoid sending
+   * duplicated COMMIT messages.
+   */
+  private Zxid lastCommittedZxid = null;
+
   protected Future<Void> future = null;
 
   private static final Logger LOG = LoggerFactory.getLogger(PeerHandler.class);
@@ -172,6 +178,14 @@ public class PeerHandler implements Callable<Void> {
 
   void setNewLeaderEpoch(int epoch) {
     this.newleaderEpoch = epoch;
+  }
+
+  Zxid getLastCommittedZxid() {
+    return this.lastCommittedZxid;
+  }
+
+  void setLastCommittedZxid(Zxid zxid) {
+    this.lastCommittedZxid = zxid;
   }
 
   /**


### PR DESCRIPTION
Currently AckProcessor sends out a commit message after each ack, even if the acknowledged transaction has already been committed. Instead, it should keep track of the last committed zxid and ignore ack if the acknowledged zxid is smaller than or equal to the last committed zxid.

=== edit: typo
