### PR TITLE
How does the application identify transactions?

### DIFF
--- a/src/main/java/org/apache/zab/CommitProcessor.java
+++ b/src/main/java/org/apache/zab/CommitProcessor.java
@@ -109,13 +109,14 @@ public class CommitProcessor implements RequestProcessor,
           int startIdx = 0;
           int endIdx = startIdx;
           for (; endIdx < this.pendingTxns.size(); ++endIdx) {
-            Transaction txn = MessageBuilder
-                              .fromProposal(this.pendingTxns.get(endIdx));
+            ZabMessage.Proposal prop = this.pendingTxns.get(endIdx);
+            Transaction txn = MessageBuilder.fromProposal(prop);
+            String clientId = prop.getClientId();
             if(zxid.compareTo(txn.getZxid()) < 0) {
               break;
             }
             LOG.debug("Delivering transaction {}.", txn.getZxid());
-            this.stateMachine.deliver(txn.getZxid(), txn.getBody());
+            this.stateMachine.deliver(txn.getZxid(), txn.getBody(), clientId);
             this.lastDeliveredZxid = txn.getZxid();
           }
           // Removes the delivered transactions.

--- a/src/main/java/org/apache/zab/MessageBuilder.java
+++ b/src/main/java/org/apache/zab/MessageBuilder.java
@@ -200,6 +200,26 @@ public final class MessageBuilder {
   }
 
   /**
+   * Creates a PROPOSAL message.
+   *
+   * @param txn the transaction of this proposal.
+   * @param clientId the id of the client who sends the request.
+   * @return a protobuf message.
+   */
+  public static Message buildProposal(Transaction txn, String clientId) {
+    ZabMessage.Zxid zxid = toProtoZxid(txn.getZxid());
+    Proposal prop = Proposal.newBuilder()
+                            .setZxid(zxid)
+                            .setBody(ByteString.copyFrom(txn.getBody()))
+                            .setClientId(clientId)
+                            .build();
+
+    return Message.newBuilder().setType(MessageType.PROPOSAL)
+                               .setProposal(prop)
+                               .build();
+  }
+
+  /**
    * Creates a DIFF message.
    *
    * @param lastZxid the last zxid of the server who initiates the sync.

--- a/src/main/java/org/apache/zab/PreProcessor.java
+++ b/src/main/java/org/apache/zab/PreProcessor.java
@@ -85,11 +85,13 @@ public class PreProcessor implements RequestProcessor,
         }
 
         ZabMessage.Request req = request.getMessage().getRequest();
+        String clientId = request.getServerId();
         ByteBuffer bufReq = req.getRequest().asReadOnlyByteBuffer();
         // Invoke the callback to convert the request into transaction.
         ByteBuffer update = this.stateMachine.preprocess(this.nextZxid, bufReq);
         Message prop = MessageBuilder
-                       .buildProposal(new Transaction(nextZxid, update));
+                       .buildProposal(new Transaction(nextZxid, update),
+                                      clientId);
 
         for (PeerHandler ph : quorumSet.values()) {
           ph.queueMessage(prop);

--- a/src/main/java/org/apache/zab/StateMachine.java
+++ b/src/main/java/org/apache/zab/StateMachine.java
@@ -49,8 +49,10 @@ public interface StateMachine {
    *
    * @param zxid zxid of the message
    * @param stateUpdate the incremental state update
+   * @param clientId the id of the client who sends the request. The request
+   * delivered in RECOVERING phase has clientId sets to null.
    */
-  void deliver(Zxid zxid, ByteBuffer stateUpdate);
+  void deliver(Zxid zxid, ByteBuffer stateUpdate, String clientId);
 
   /**
    * Upcall to serialize the application state using an
@@ -82,7 +84,7 @@ public interface StateMachine {
    * state.
    *
    * @param state the current state of Zab, it could be
-   * LOOING/FOLLOWING/LEADING.
+   * RECOVERING/FOLLOWING/LEADING.
    */
-  void stateChanged(Zab.ZabState state);
+  void stateChanged(Zab.State state);
 }

--- a/src/main/java/org/apache/zab/Zab.java
+++ b/src/main/java/org/apache/zab/Zab.java
@@ -32,7 +32,7 @@ public abstract class Zab {
   /**
    * The state of the Zab.
    */
-  public enum ZabState {
+  public enum State {
     LOOKING,
     LEADING,
     FOLLOWING

--- a/src/main/resources/zab_message.proto
+++ b/src/main/resources/zab_message.proto
@@ -78,6 +78,8 @@ message Proposal {
   required Zxid zxid = 1;
   // Transaction body.
   required bytes body = 2;
+  // The id of the client who sends the request.
+  optional string clientId = 3;
 }
 
 message Diff {

--- a/src/test/java/org/apache/zab/TestStateMachine.java
+++ b/src/test/java/org/apache/zab/TestStateMachine.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import org.apache.zab.Zab.ZabState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +54,9 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void deliver(Zxid zxid, ByteBuffer stateUpdate) {
+  public void deliver(Zxid zxid, ByteBuffer stateUpdate, String clientId) {
     // Add the delivered message to list.
-    LOG.debug("Delivers txn {}", zxid);
+    LOG.debug("Delivers txn {}. Origin : {}", zxid, clientId);
     this.deliveredTxns.add(new Transaction(zxid, stateUpdate));
 
     if (txnsCount != null) {
@@ -78,6 +77,6 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void stateChanged(ZabState state) {
+  public void stateChanged(Zab.State state) {
   }
 }


### PR DESCRIPTION
Application needs to be able to identify transactions and match them up with pending requests. Using zabkv as an example, zabkv needs to match up delivered transactions with HTTP request contexts so that it knows which HTTP request to respond to. 

Since zab delivers transactions in the same order it receives them, I'm thinking that zabkv can store the HTTP request context in a queue so long as it can identify the origin of the transaction. To identify the origin, we can either change the deliver method to pass the origin or let zabkv encode the origin into the message. So the request flow looks like this:
1. zabkv receives an HTTP PUT request to create a key-value pair.
2. zabkv calls zab.send() and puts the HTTP request context in a queue.
3. When the transaction is committed, zab calls deliver().
4. In deliver(), zabkv updates the state machine. If the origin of the transaction is itself, zabkv dequeues the HTTP request context and responds to the HTTP request.
5. When zab goes back to LOOKING state, zabkv responds to all the HTTP requests in the queue with a 5xx error and clear the queue. 

Does this sound reasonable? There is a related discussion in zookeeper-30:

https://issues.apache.org/jira/browse/ZOOKEEPER-30?focusedCommentId=12688994&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12688994
