### PR TITLE
clean up cluster state change callbacks

### DIFF
--- a/src/test/java/org/apache/zab/QuorumZabTest.java
+++ b/src/test/java/org/apache/zab/QuorumZabTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.zab.QuorumZab.FailureCaseCallback;
 import org.apache.zab.QuorumZab.SimulatedException;
 import org.apache.zab.transport.DummyTransport.Message;

--- a/src/test/java/org/apache/zab/TestStateMachine.java
+++ b/src/test/java/org/apache/zab/TestStateMachine.java
@@ -78,11 +78,18 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void stateChanged(Zab.State state) {
+  public void recovering() {
   }
 
   @Override
-  public void membersChange(Set<String> members) {
-    LOG.debug("members change.");
+  public void leading(Set<String> activeFollowers) {
+  }
+
+  @Override
+  public void following(String leader) {
+  }
+
+  @Override
+  public void clusterChange(Set<String> servers) {
   }
 }


### PR DESCRIPTION
There are 3 types of callbacks for state changes:
- participant state change (leading/following/recovering)
- cluster member change (node join / leave)
- active follower list change

The cluster member change should be something like:

```
void clusterChanged(List<String> servers);
```

For the participant state change and active follower list change, maybe we could do something like:

```
void leading(List<String> activeFollowers);
void following(String leader);
void recovering();
```
