### PR TITLE
Server state MDC doesn't get set when starting a single server?

### DIFF
--- a/src/main/java/org/apache/zab/Follower.java
+++ b/src/main/java/org/apache/zab/Follower.java
@@ -40,6 +40,7 @@ public class Follower extends Participant {
                   StateMachine stateMachine,
                   ZabConfig config) {
     super(participantState, stateMachine, config);
+    MDC.put("state", "following");
   }
 
   /**
@@ -410,11 +411,7 @@ public class Follower extends Participant {
           if (LOG.isDebugEnabled()) {
             LOG.debug("Got COP {}", TextFormat.shortDebugString(msg));
           }
-          ClusterConfiguration cnf =
-            ClusterConfiguration.fromProto(msg.getConfig(), this.serverId);
-          persistence.setLastSeenConfig(cnf);
-          Message ackCop = MessageBuilder.buildAckCop(cnf.getVersion());
-          sendMessage(this.electedLeader, ackCop);
+          onCop(tuple);
           if (!persistence.getLastSeenConfig().contains(this.serverId)) {
             LOG.debug("{} has been removed from the cluster.", this.serverId);
             throw new LeftCluster("Server has been removed from the cluster");

--- a/src/test/java/org/apache/zab/QuorumZabTest.java
+++ b/src/test/java/org/apache/zab/QuorumZabTest.java
@@ -1580,6 +1580,7 @@ public class QuorumZabTest extends TestBase  {
                                                 null,
                                                 getDirectory());
     QuorumZab zab1 = new QuorumZab(st1, cb1, null, state1, server1);
+    cb1.waitBroadcasting();
 
     QuorumZab.TestState state2 = new QuorumZab
                                      .TestState(server2,


### PR DESCRIPTION
From the log, it looks like the server state MDC ("leading|following|recovering") is not set when you start the first server.

```
2014-08-09 18:22:01,637 INFO  com.github.zk1931.pulsed.Main.main() org.eclipse.jetty.util.log:188 Logging initialized @7248ms
2014-08-09 18:22:01,686 INFO  com.github.zk1931.pulsed.Main.main() org.eclipse.jetty.server.Server:300 jetty-9.2.1.v20140609
2014-08-09 18:22:01,719 DEBUG com.github.zk1931.pulsed.Main.main() org.apache.zab.PersistentState:73 [||] Trying to create log directory /home/michi/gitdev/pulsed/localhost:5000
2014-08-09 18:22:01,721 DEBUG com.github.zk1931.pulsed.Main.main() org.apache.zab.SimpleLog:76 [||] SimpleLog constructed. The lastSeenZxid is Zxid [epoch: 0, xid: -1].
2014-08-09 18:22:01,830 INFO  com.github.zk1931.pulsed.Main.main() o.a.zab.transport.NettyTransport:103 [||] Server started: localhost:5000
2014-08-09 18:22:01,831 DEBUG Thread-10 org.apache.zab.QuorumZab:201 [||localhost:5000] QuorumZab starts running.
2014-08-09 18:22:01,833 DEBUG Thread-10 org.apache.zab.QuorumZab:244 [||localhost:5000] Trying to join itself. Becomes leader directly.
2014-08-09 18:22:01,838 INFO  com.github.zk1931.pulsed.Main.main() o.e.jetty.server.ServerConnector:266 Started ServerConnector@5d6237b1{HTTP/1.1}{0.0.0.0:8080}
2014-08-09 18:22:01,838 INFO  com.github.zk1931.pulsed.Main.main() org.eclipse.jetty.server.Server:349 Started @7454ms
2014-08-09 18:22:01,849 DEBUG Thread-10 org.apache.zab.FileUtils:107 [||localhost:5000] Atomically moved /home/michi/gitdev/pulsed/localhost:5000/cluster_config8366985397919797614.tmp to localhost:5000/cluster_config
2014-08-09 18:22:01,858 DEBUG Thread-10 org.apache.zab.FileUtils:67 [||localhost:5000] Atomically moved /home/michi/gitdev/pulsed/localhost:5000/proposed_epoch1023623821417933705.tmp to localhost:5000/proposed_epoch
2014-08-09 18:22:01,869 DEBUG Thread-10 org.apache.zab.FileUtils:67 [||localhost:5000] Atomically moved /home/michi/gitdev/pulsed/localhost:5000/ack_epoch690835458468844272.tmp to localhost:5000/ack_epoch
2014-08-09 18:22:01,870 DEBUG Thread-10 org.apache.zab.Leader:503 [|broadcasting|localhost:5000] Begins broadcasting!
2014-08-09 18:22:01,872 DEBUG pool-1-thread-1 org.apache.zab.PeerHandler:258 [|broadcasting|localhost:5000] BroadcastingFollower to localhost:5000 task gets started.
2014-08-09 18:22:01,873 DEBUG Thread-11 org.apache.zab.PreProcessor:86 [|broadcasting|localhost:5000] PreProcessor gets started.
2014-08-09 18:22:01,874 DEBUG Thread-12 org.apache.zab.AckProcessor:85 [|broadcasting|localhost:5000] AckProcessor gets started.
2014-08-09 18:22:01,875 DEBUG Thread-13 o.apache.zab.SyncProposalProcessor:91 [|broadcasting|localhost:5000] Batched SyncRequestProcessor gets started.
2014-08-09 18:22:01,876 DEBUG Thread-14 org.apache.zab.CommitProcessor:83 [|broadcasting|localhost:5000] CommitProcessor gets started.
```
