### PR TITLE
quorumSet of leader should be ConCurrentHashMap instead of just HashMap

### DIFF
--- a/src/main/java/org/apache/zab/Leader.java
+++ b/src/main/java/org/apache/zab/Leader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +43,7 @@ import org.slf4j.MDC;
 public class Leader extends Participant {
 
   private final Map<String, PeerHandler> quorumSet =
-    new HashMap<String, PeerHandler>();
+    new ConcurrentHashMap<String, PeerHandler>();
 
   private static final Logger LOG = LoggerFactory.getLogger(Leader.class);
 


### PR DESCRIPTION
In our current implementation different processors will read quorumSet while main thread will change quorumSet. It has a very low probabilities of causing "concurrent modification exception".
