### PR TITLE
Participant should buffer send request before broadcasting phase. 

### DIFF
--- a/src/main/java/org/apache/zab/Follower.java
+++ b/src/main/java/org/apache/zab/Follower.java
@@ -352,6 +352,8 @@ public class Follower extends Participant {
     long lastHeartbeatTime = System.nanoTime();
     int ackEpoch = persistence.getAckEpoch();
     this.stateMachine.following(this.electedLeader);
+    // Starts thread to process request in request queue.
+    SendRequestTask sendTask = new SendRequestTask(this.electedLeader);
     try {
       while (true) {
         MessageTuple tuple = getMessage();
@@ -425,6 +427,7 @@ public class Follower extends Participant {
         }
       }
     } finally {
+      sendTask.shutdown();
       commitProcessor.shutdown();
       syncProcessor.shutdown();
       this.lastDeliveredZxid = commitProcessor.getLastDeliveredZxid();

--- a/src/main/java/org/apache/zab/Leader.java
+++ b/src/main/java/org/apache/zab/Leader.java
@@ -532,6 +532,8 @@ public class Leader extends Participant {
         new HashSet<String>(persistence.getLastSeenConfig().getPeers()));
     // First time call leading callback.
     notifyQuorumSetChange();
+    // Starts thread to process request in request queue.
+    SendRequestTask sendTask = new SendRequestTask(this.serverId);
     try {
       while (true) {
         if (pendingConfig != null) {
@@ -689,6 +691,7 @@ public class Leader extends Participant {
           + "quorum size {}, goes back to electing phase.",
           getQuorumSize());
     } finally {
+      sendTask.shutdown();
       ackProcessor.shutdown();
       preProcessor.shutdown();
       commitProcessor.shutdown();

--- a/src/main/java/org/apache/zab/ParticipantState.java
+++ b/src/main/java/org/apache/zab/ParticipantState.java
@@ -54,6 +54,13 @@ public class ParticipantState implements Transport.Receiver {
     new LinkedBlockingQueue<MessageTuple>();
 
   /**
+   * Request queue. This queue buffers all the outgoing requests from clients,
+   * they will be processed once Participant enters broadcasting phase.
+   */
+  private final BlockingQueue<MessageTuple> requestQueue =
+    new LinkedBlockingQueue<MessageTuple>();
+
+  /**
    * Used for communication between nodes.
    */
   private final Transport transport;
@@ -109,6 +116,10 @@ public class ParticipantState implements Transport.Receiver {
     return this.messageQueue;
   }
 
+  public BlockingQueue<MessageTuple> getRequestQueue() {
+    return this.requestQueue;
+  }
+
   public String getServerId() {
     return this.serverId;
   }
@@ -127,6 +138,16 @@ public class ParticipantState implements Transport.Receiver {
 
   public void updateLastDeliveredZxid(Zxid zxid) {
     this.lastDeliveredZxid = zxid;
+  }
+
+  public void enqueueRequest(ByteBuffer buffer) {
+    Message msg = MessageBuilder.buildRequest(buffer);
+    this.requestQueue.add(new MessageTuple(this.serverId, msg));
+  }
+
+  public void enqueueLeave() {
+    Message msg = MessageBuilder.buildLeave(this.serverId);
+    this.requestQueue.add(new MessageTuple(this.serverId, msg));
   }
 }
 


### PR DESCRIPTION
Currently if the client send a request before broadcasting phase we'll raise an exception. We should buffer the request and process them once participant enters the broadcasting phase.
