### PR TITLE
combine clusterChange and leading/following callbacks?

### DIFF
--- a/src/main/java/org/apache/zab/StateMachine.java
+++ b/src/main/java/org/apache/zab/StateMachine.java
@@ -72,14 +72,6 @@ public interface StateMachine {
   void setState(InputStream is);
 
   /**
-   * Upcall to notify all the servers the cluster configuration changes. This
-   * happens when the server receives COP message.
-   *
-   * @param servers the servers in new configuration.
-   */
-  void clusterChange(Set<String> servers);
-
-  /**
    * Upcall to notify the server it's in recovering phase. Servers in recovering
    * phase shouldn't issue or process any requests.
    */
@@ -87,19 +79,24 @@ public interface StateMachine {
 
   /**
    * Upcall to notify the application who is running on the leader role of ZAB
-   * instance. This callback will be called once ZAB enters broadcasting phase
-   * or the membership of active followers is changed.
+   * instance the membership changes of Zab cluster. The membership changes
+   * include the detection of recovered members or disconnected members in
+   * current configuration or new configuration after some one joined or be
+   * removed from current configuration.
    *
    * @param activeFollowers current alive followers.
+   * @param clusterMembers the members of new configuration.
    */
-  void leading(Set<String> activeFollowers);
+  void leading(Set<String> activeFollowers, Set<String> clusterMembers);
 
   /**
-   * Upcall to notify the application who is running on follower role of ZAB
-   * instance. This callback will be called once the ZAB enters the broadcasting
-   * phase.
+   * Upcall to notify the application who is running on the follower role of ZAB
+   * instance the membership changes of Zab cluster. The membership changes
+   * include the detection of the leader or the new cluster configuration after
+   * some servers are joined or removed.
    *
-   * @param leader the elected leader for this follower.
+   * @param leader current leader.
+   * @param clusterMembers the members of new configuration.
    */
-  void following(String leader);
+  void following(String leader, Set<String> clusterMembers);
 }

--- a/src/test/java/org/apache/zab/QuorumZabTest.java
+++ b/src/test/java/org/apache/zab/QuorumZabTest.java
@@ -1947,8 +1947,7 @@ public class QuorumZabTest extends TestBase  {
                                                 getDirectory());
     QuorumZab zab1 = new QuorumZab(st1, cb1, null, state1, server1);
     // Waits for clusterChange and leading callback.
-    st1.waitBroadcasting();
-    st1.waitClusterChange();
+    st1.waitMembershipChanged();
     // Make sure first config contains itself.
     Assert.assertTrue(st1.clusters.contains(server1));
     // The cluster size should be 1.
@@ -1958,15 +1957,13 @@ public class QuorumZabTest extends TestBase  {
                                                 null,
                                                 getDirectory());
     QuorumZab zab2 = new QuorumZab(st2, cb2, null, state2, server1);
-    st2.waitBroadcasting();
-    st2.waitClusterChange();
+    st2.waitMembershipChanged();
     // Make sure first config contains itself.
     Assert.assertTrue(st2.clusters.contains(server1));
     // The cluster size should be 2.
     Assert.assertEquals(2, st2.clusters.size());
     // Now the callback will be called again.
-    st1.waitBroadcasting();
-    st1.waitClusterChange();
+    st1.waitMembershipChanged();
     // Make sure first config contains itself.
     Assert.assertTrue(st1.clusters.contains(server1));
     // The cluster size should be 1.
@@ -2077,15 +2074,15 @@ public class QuorumZabTest extends TestBase  {
       QuorumZab zab = new QuorumZab(st, cb, null, state, server1);
       // Waits for reconfig completes.
       cb1.waitCopCommit();
-      st1.waitClusterChange();
-      st.waitClusterChange();
+      st1.waitMembershipChanged();
+      st.waitMembershipChanged();
       // Make sure first config contains itself.
       Assert.assertTrue(st.clusters.contains(server));
       // Remove new joined server.
       zab1.remove(server);
       // Waits for reconfig completes.
       cb1.waitCopCommit();
-      st1.waitClusterChange();
+      st1.waitMembershipChanged();
       cb.waitExit();
     }
     // Finally, the server1 has the configuration of single server.
@@ -2119,37 +2116,37 @@ public class QuorumZabTest extends TestBase  {
                                                 null,
                                                 getDirectory());
     QuorumZab zab1 = new QuorumZab(st1, cb1, null, state1, server1);
-    // Waits for clusterChange and leading callback.
-    st1.waitClusterChange();
+    // Waits for leader goes into broadcasting phase.
+    st1.waitMembershipChanged();
 
     QuorumZab.TestState state2 = new QuorumZab
                                      .TestState(server2,
                                                 null,
                                                 getDirectory());
     QuorumZab zab2 = new QuorumZab(st2, cb2, null, state2, server1);
-    st2.waitBroadcasting();
-    st2.waitClusterChange();
-    st1.waitClusterChange();
+    st2.waitMembershipChanged();
+    st1.waitMembershipChanged();
+    cb2.waitBroadcasting();
 
     QuorumZab.TestState state3 = new QuorumZab
                                      .TestState(server3,
                                                 null,
                                                 getDirectory());
     QuorumZab zab3 = new QuorumZab(st3, cb3, null, state3, server1);
-    st3.waitBroadcasting();
-    st3.waitClusterChange();
-    st2.waitClusterChange();
-    st1.waitClusterChange();
+    st1.waitMembershipChanged();
+    st2.waitMembershipChanged();
+    st3.waitMembershipChanged();
+    cb3.waitBroadcasting();
+
     // Server1 exits.
     zab1.remove(server1);
-    st3.waitClusterChange();
-    st2.waitClusterChange();
-    st1.waitClusterChange();
     // Waits server1 exit.
     cb1.waitExit();
     // server2 and server3 should go back recovery and form a new quorum.
-    st3.waitBroadcasting();
-    st2.waitBroadcasting();
+    cb3.waitBroadcasting();
+    cb2.waitBroadcasting();
+    st2.waitMembershipChanged();
+    st3.waitMembershipChanged();
     // The cluster size should be 2.
     Assert.assertEquals(2, st2.clusters.size());
     Assert.assertEquals(2, st3.clusters.size());


### PR DESCRIPTION
Right now we call clusterChange and leading/following callbacks separately. Maybe it's cleaner to combine these callbacks:

```
void following(String leader, Set<String> clusterMembers);
void leading(Set<String> activeFollowers, Set<String> clusterMEmbers);
```
