### PR TITLE
clean up cluster_config format

### DIFF
--- a/src/main/java/org/apache/zab/ClusterConfiguration.java
+++ b/src/main/java/org/apache/zab/ClusterConfiguration.java
@@ -76,8 +76,11 @@ class ClusterConfiguration {
     Properties prop = new Properties();
     StringBuilder strBuilder = new StringBuilder();
     String strVersion = this.version.toSimpleString();
-    for (String peer : this.peers) {
-      strBuilder.append(peer + ",");
+    if (!this.peers.isEmpty()) {
+      strBuilder.append(this.peers.get(0));
+      for (int i = 1; i < this.peers.size(); ++i) {
+        strBuilder.append("," + this.peers.get(i));
+      }
     }
     prop.setProperty("peers", strBuilder.toString());
     prop.setProperty("version", strVersion);

--- a/src/test/java/org/apache/zab/RoundRobinElectionTest.java
+++ b/src/test/java/org/apache/zab/RoundRobinElectionTest.java
@@ -36,9 +36,8 @@ final class DummyPersistentState {
       throws IOException {
     PersistentState persistence = new PersistentState(directory);
     List<String> peerList = Arrays.asList(peers.split(";"));
-    ClusterConfiguration cnf = new ClusterConfiguration(Zxid.ZXID_NOT_EXIST,
-                                                        peerList,
-                                                        "host");
+    ClusterConfiguration cnf =
+      new ClusterConfiguration(new Zxid(0, 0), peerList, "host");
     persistence.setLastSeenConfig(cnf);
     persistence.setProposedEpoch(epoch);
     return persistence;

--- a/src/test/java/org/apache/zab/SyncProposalProcessorTest.java
+++ b/src/test/java/org/apache/zab/SyncProposalProcessorTest.java
@@ -121,12 +121,10 @@ public class SyncProposalProcessorTest extends TestBase {
     TestReceiver receiver = new TestReceiver();
     Transport transport = new NettyTransport(leader, receiver, getDirectory());
     ClusterConfiguration cnf =
-      new ClusterConfiguration(Zxid.ZXID_NOT_EXIST,
-                               new ArrayList<String>(), "");
+      new ClusterConfiguration(new Zxid(0, 0), new ArrayList<String>(), "");
     persistence.setLastSeenConfig(cnf);
-    SyncProposalProcessor processor = new SyncProposalProcessor(persistence,
-                                                                transport,
-                                                                batchSize);
+    SyncProposalProcessor processor =
+      new SyncProposalProcessor(persistence, transport, batchSize);
     long startTime = System.nanoTime();
     String message = new String(new char[transactionSize]).replace('\0', 'a');
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
Currently it looks something like this:

```
#
#Sat Aug 09 18:22:01 PDT 2014
peers=localhost\:5000,
version=0 -1
serverId=localhost\:5000
```
- We can remove the date. We can look at the file timestamp to find out when it got created.
- The version should be zxid, and it should probably be a part of the filename ("cluster_config.epoch.xid" for example).
- No need to escape colons.
- peers has a trailing comma.
- Maybe it's better to have one field called "servers". We can use the first server in the servers field as the local server id. 
