### PR TITLE
Fix the bug in AckProcessor.

### DIFF
--- a/src/main/java/org/apache/zab/AckProcessor.java
+++ b/src/main/java/org/apache/zab/AckProcessor.java
@@ -175,8 +175,15 @@ public class AckProcessor implements RequestProcessor,
               // are just acknowledged by a quorum of old configuration.
               Zxid version = pendingConfig.getVersion();
               // Then commit the transactions up to the one before COP.
-              zxidCanCommit =
-                new Zxid(version.getEpoch(), version.getXid() - 1);
+              if (version.getXid() == 0) {
+                // Means the COP is the first transaction in this epoch, no
+                // transactions before COP needs to be committed.
+                zxidCanCommit = lastCommittedZxid;
+              } else {
+                // We can commit the transaction up to the one before COP.
+                zxidCanCommit =
+                  new Zxid(version.getEpoch(), version.getXid() - 1);
+              }
             }
             LOG.debug("Zxid can be committed for current configuration is {}",
                       zxidCanCommit);


### PR DESCRIPTION
This is the bug we found while we were preparing the demo for my final talk.

If there's a pending configuration in AckProcessor, it will first find the zxid can be committed in pending configuration. If the pending configuration can't be committed, it will find the zxid can be committed in current configuration. It's possible that the zxid can be committed for current configuration is larger than the zxid of COP. In this case, we will only commit the transaction before COP like : 
`zxidCanCommit = new Zxid(copVersion.getEpoch(), copVersion.getXid() - 1)`

However, it's possible that the COP is the first transaction in a new epoch, let's say it has `Zxid <1, 0>`, then `zxidCanCommit = <1, -1>`, which is incorrect.
