### PR TITLE
Use Semaphore to avoid the internal queues grow infinitely.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -95,7 +95,6 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="LineLength"/>
-    <module name="ParameterNumber"/>
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->

--- a/src/main/java/org/apache/zab/Follower.java
+++ b/src/main/java/org/apache/zab/Follower.java
@@ -352,7 +352,8 @@ public class Follower extends Participant {
       new SyncProposalProcessor(persistence, transport, SYNC_MAX_BATCH_SIZE);
     CommitProcessor commitProcessor
       = new CommitProcessor(stateMachine, lastDeliveredZxid, serverId,
-                            transport, null, clusterConfig, electedLeader);
+                            transport, null, clusterConfig, electedLeader,
+                            semPendingReqs);
     SnapshotProcessor snapProcessor =
       new SnapshotProcessor(stateMachine, persistence);
     // The last time of HEARTBEAT message comes from leader.

--- a/src/main/java/org/apache/zab/Leader.java
+++ b/src/main/java/org/apache/zab/Leader.java
@@ -550,7 +550,7 @@ public class Leader extends Participant {
     CommitProcessor commitProcessor =
         new CommitProcessor(stateMachine, lastDeliveredZxid, serverId,
                             transport, new HashSet<String>(quorumSet.keySet()),
-                            clusterConfig, electedLeader);
+                            clusterConfig, electedLeader, semPendingReqs);
     SnapshotProcessor snapProcessor =
       new SnapshotProcessor(stateMachine, persistence);
     // First time notifies the client active members and cluster configuration.

--- a/src/main/java/org/apache/zab/ParticipantState.java
+++ b/src/main/java/org/apache/zab/ParticipantState.java
@@ -57,7 +57,7 @@ public class ParticipantState implements Transport.Receiver {
    * they will be processed once Participant enters broadcasting phase.
    */
   private final BlockingQueue<MessageTuple> requestQueue =
-    new LinkedBlockingQueue<MessageTuple>();
+    new LinkedBlockingQueue<MessageTuple>(ZabConfig.MAX_PENDING_REQS);
 
   /**
    * Used for communication between nodes.
@@ -123,17 +123,29 @@ public class ParticipantState implements Transport.Receiver {
 
   public void enqueueRequest(ByteBuffer buffer) {
     Message msg = MessageBuilder.buildRequest(buffer);
-    this.requestQueue.add(new MessageTuple(this.serverId, msg));
+    try {
+      this.requestQueue.put(new MessageTuple(this.serverId, msg));
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted Exception");
+    }
   }
 
   public void enqueueRemove(String peerId) {
     Message msg = MessageBuilder.buildRemove(peerId);
-    this.requestQueue.add(new MessageTuple(this.serverId, msg));
+    try {
+      this.requestQueue.put(new MessageTuple(this.serverId, msg));
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted Exception");
+    }
   }
 
   public void enqueueFlush(ByteBuffer buffer) {
     Message msg = MessageBuilder.buildFlushRequest(buffer);
-    this.requestQueue.add(new MessageTuple(this.serverId, msg));
+    try {
+      this.requestQueue.put(new MessageTuple(this.serverId, msg));
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted Exception");
+    }
   }
 }
 

--- a/src/main/java/org/apache/zab/ZabConfig.java
+++ b/src/main/java/org/apache/zab/ZabConfig.java
@@ -27,7 +27,14 @@ import java.util.Properties;
  * Simple wrapper on Properties, provides a way to query configuration.
  */
 public class ZabConfig {
+
+  /**
+   * Maximum number of pending requests allowed for each server.
+   */
+  static final int MAX_PENDING_REQS = 20000;
+
   protected Properties prop;
+
   protected List<String> peers = null;
 
   /**


### PR DESCRIPTION
Since the `send` are asynchronous, it's possible that the users keep sending stuff so the requests are accumulating in the various internal queues of Zab. Solve this by adding a Semaphore represents the maximum number of outstanding request to avoid this.  
