### PR TITLE
transaction log improvements

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -22,7 +22,7 @@
 <!-- Ignoring protobuf generated files. -->
 <FindBugsFilter>
   <Match>
-    <Package name="org.apache.zab.proto" />
+    <Package name="com.github.zk1931.jzab.proto" />
   </Match>
 </FindBugsFilter>
 


### PR DESCRIPTION
- Add checksum for each transaction.
- Improve performance. Right now the implementation is pretty naive. We can experiment with pre-allocation, reusing log files, etc..
- Add transaction type. With COP (and maybe NEW_LEADER), it would be nice to know transaction type of each record.
