### PR TITLE
The cluster gets blocked while somebody is joining

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/MessageBuilder.java
+++ b/src/main/java/com/github/zk1931/jzab/MessageBuilder.java
@@ -427,8 +427,11 @@ public final class MessageBuilder {
    *
    * @return a protobuf message.
    */
-  public static Message buildJoin() {
-    return Message.newBuilder().setType(MessageType.JOIN).build();
+  public static Message buildJoin(Zxid lastZxid) {
+    ZabMessage.Zxid zxid = toProtoZxid(lastZxid);
+    ZabMessage.Join join =
+      ZabMessage.Join.newBuilder().setLastZxid(zxid).build();
+    return Message.newBuilder().setType(MessageType.JOIN).setJoin(join).build();
   }
 
   /**
@@ -559,6 +562,14 @@ public final class MessageBuilder {
                                              .build();
     return Message.newBuilder().setType(MessageType.FLUSH).setFlush(flush)
                   .build();
+  }
+
+  /**
+   * Creates a SYNC_HISTORY message. Leader will synchronize everything it has
+   * to follower after receiving this message.
+   */
+  public static Message buildSyncHistory() {
+    return Message.newBuilder().setType(MessageType.SYNC_HISTORY).build();
   }
 }
 

--- a/src/main/resources/zab_message.proto
+++ b/src/main/resources/zab_message.proto
@@ -35,6 +35,8 @@ message Message {
     FILE_RECEIVED = 26;
     FLUSH_REQ = 27;
     FLUSH = 28;
+    // The request of synchronizing the log.
+    SYNC_HISTORY = 29;
     INVALID_MESSAGE = 30;
   }
 
@@ -65,6 +67,7 @@ message Message {
   optional FileReceived file_received = 21;
   optional FlushRequest flush_request = 22;
   optional Flush flush = 23;
+  optional Join join = 24;
   optional InvalidMessage invalid = 30;
 }
 
@@ -168,6 +171,10 @@ message ClusterConfiguration {
 
 message QueryReply {
   required string leader = 1;
+}
+
+message Join {
+  required Zxid lastZxid = 1;
 }
 
 message Remove {

--- a/src/test/java/com/github/zk1931/jzab/AckProcessorTest.java
+++ b/src/test/java/com/github/zk1931/jzab/AckProcessorTest.java
@@ -76,7 +76,7 @@ public class AckProcessorTest extends TestBase {
   }
 
   private MessageTuple createJoin(String source, Zxid zxid) {
-    Message join = MessageBuilder.buildJoin();
+    Message join = MessageBuilder.buildJoin(Zxid.ZXID_NOT_EXIST);
     return new MessageTuple(source, join, zxid);
   }
 


### PR DESCRIPTION
This happens when cluster size gets changed from 1 to 2.  Since the new joined guy takes some time for synchronization, so all the transactions after COP get blocked until the new joined server gets synchronized.

Solve this by doing 2-phase synchronization. 
