### PR TITLE
Fix the bug of communicating the sync timeout value.

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/Leader.java
+++ b/src/main/java/com/github/zk1931/jzab/Leader.java
@@ -371,6 +371,7 @@ public class Leader extends Participant {
       PeerHandler ph = new PeerHandler(source, transport,
                                        config.getTimeoutMs()/3);
       ph.setLastProposedEpoch(peerProposedEpoch);
+      ph.setSyncTimeoutMs(syncTimeoutMs);
       this.quorumSet.put(source, ph);
     }
     LOG.debug("Got proposed epoch from a quorum.");


### PR DESCRIPTION
Forgot storing sync timeout value to PeerHandler after receiving PROPOSED_EPOCH message.
