### PR TITLE
fix the warning in SyncProposalProcessorTest.java

### DIFF
--- a/src/test/java/com/github/zk1931/jzab/LogTest.java
+++ b/src/test/java/com/github/zk1931/jzab/LogTest.java
@@ -42,7 +42,7 @@ public class LogTest extends TestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogTest.class);
 
-  Class logClass;
+  Class<Log> logClass;
 
   String fileName;
 
@@ -55,7 +55,7 @@ public class LogTest extends TestBase {
       });
   }
 
-  public LogTest(Class logClass, String fileName) {
+  public LogTest(Class<Log> logClass, String fileName) {
     LOG.debug("Testting impelementation of {}", logClass);
     this.logClass = logClass;
     this.fileName = fileName;
@@ -63,12 +63,12 @@ public class LogTest extends TestBase {
 
   Log getLog() throws Exception {
     File f = new File(getDirectory(), this.fileName);
-    if (logClass == RollingLog.class) {
+    if (logClass == (Class<?>)RollingLog.class) {
       // For testing purpose, set the rolling size to be very small.
-      return (Log)logClass.getConstructor(File.class, Long.TYPE)
+      return logClass.getConstructor(File.class, Long.TYPE)
                           .newInstance(f, 128);
     } else {
-      return (Log)logClass.getConstructor(File.class).newInstance(f);
+      return logClass.getConstructor(File.class).newInstance(f);
     }
   }
 
@@ -221,7 +221,7 @@ public class LogTest extends TestBase {
 
   @Test(expected=RuntimeException.class)
   public void testCorruptChecksum() throws Exception {
-    if (logClass == SimpleLog.class) {
+    if (logClass == (Class<?>)SimpleLog.class) {
       Log log = getLog();
       appendTxns(log, new Zxid(0, 0), 1);
       // Corrupts checksum.
@@ -236,7 +236,7 @@ public class LogTest extends TestBase {
 
   @Test(expected=RuntimeException.class)
   public void testCorruptLength() throws Exception {
-    if (logClass == SimpleLog.class) {
+    if (logClass == (Class<?>)SimpleLog.class) {
       Log log = getLog();
       appendTxns(log, new Zxid(0, 0), 1);
       // Corrupts length.
@@ -251,7 +251,7 @@ public class LogTest extends TestBase {
 
   @Test(expected=RuntimeException.class)
   public void testCorruptZxid() throws Exception {
-    if (logClass == SimpleLog.class) {
+    if (logClass == (Class<?>)SimpleLog.class) {
       Log log = getLog();
       appendTxns(log, new Zxid(0, 0), 1);
       // Corrupts zxid.
@@ -266,7 +266,7 @@ public class LogTest extends TestBase {
 
   @Test(expected=RuntimeException.class)
   public void testCorruptType() throws Exception {
-    if (logClass == SimpleLog.class) {
+    if (logClass == (Class<?>)SimpleLog.class) {
       Log log = getLog();
       appendTxns(log, new Zxid(0, 0), 1);
       // Corrupts type.
@@ -281,7 +281,7 @@ public class LogTest extends TestBase {
 
   @Test(expected=RuntimeException.class)
   public void testCorruptTxn() throws Exception {
-    if (logClass == SimpleLog.class) {
+    if (logClass == (Class<?>)SimpleLog.class) {
       Log log = getLog();
       appendTxns(log, new Zxid(0, 0), 1);
       // Corrupts Transaction.

--- a/src/test/java/com/github/zk1931/jzab/SnapshotProcessorTest.java
+++ b/src/test/java/com/github/zk1931/jzab/SnapshotProcessorTest.java
@@ -106,7 +106,7 @@ public class SnapshotProcessorTest extends TestBase {
     sp.shutdown();
     File snap = persistence.getSnapshotFile();
     ObjectInputStream oi = new ObjectInputStream(new FileInputStream(snap));
-    HashSet<String> stateRestored = (HashSet<String>)oi.readObject();
+    HashSet stateRestored = (HashSet)oi.readObject();
     // Make sure the snapshot is correct.
     Assert.assertEquals(state, stateRestored);
   }

--- a/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
+++ b/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
@@ -28,6 +28,8 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.junit.Assert;
@@ -84,7 +86,13 @@ class SnapshotStateMachine implements StateMachine {
     LOG.debug("RESTORE is called.");
     try {
       ObjectInputStream oin = new ObjectInputStream(is);
-      state = (ConcurrentHashMap<String, String>)oin.readObject();
+      ConcurrentHashMap<?, ?> map = (ConcurrentHashMap<?, ?>)oin.readObject();
+      state = new ConcurrentHashMap<String, String>();
+      Iterator it = map.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry pairs = (Map.Entry)it.next();
+        state.put((String)pairs.getKey(), (String)pairs.getValue());
+      }
       LOG.debug("The size of map after recovery from snapshot file is {}",
                 state.size());
     } catch (Exception e) {

--- a/src/test/java/com/github/zk1931/jzab/SyncProposalProcessorTest.java
+++ b/src/test/java/com/github/zk1931/jzab/SyncProposalProcessorTest.java
@@ -49,7 +49,7 @@ public class SyncProposalProcessorTest extends TestBase {
     LOG.setLevel(Level.INFO);
   }
 
-  Class logClass;
+  Class<Log> logClass;
 
   String fileName;
 
@@ -62,7 +62,7 @@ public class SyncProposalProcessorTest extends TestBase {
       });
   }
 
-  public SyncProposalProcessorTest(Class logClass, String fileName) {
+  public SyncProposalProcessorTest(Class<Log> logClass, String fileName) {
     LOG.debug("Testting impelementation of {}", logClass.getName());
     this.logClass = logClass;
     this.fileName = fileName;
@@ -72,12 +72,12 @@ public class SyncProposalProcessorTest extends TestBase {
     File fSub = new File(getDirectory(), subdir);
     fSub.mkdir();
     File f = new File(fSub, this.fileName);
-    if (logClass == RollingLog.class) {
+    if (logClass == (Class<?>)RollingLog.class) {
       // For testing purpose, set the rolling size be small.
-      return (Log)logClass.getConstructor(File.class, Long.TYPE)
-                          .newInstance(f, 10 * 1024 * 1024);
+      return logClass.getConstructor(File.class, Long.TYPE)
+                     .newInstance(f, 10 * 1024 * 1024);
     } else {
-      return (Log)logClass.getConstructor(File.class).newInstance(f);
+      return logClass.getConstructor(File.class).newInstance(f);
     }
   }
 


### PR DESCRIPTION
[WARNING] /home/michi/gitdev/jzab/src/test/java/com/github/zk1931/jzab/SyncProposalProcessorTest.java: Some input files use unchecked or unsafe operations.
[WARNING] /home/michi/gitdev/jzab/src/test/java/com/github/zk1931/jzab/SyncProposalProcessorTest.java: Recompile with -Xlint:unchecked for details.
