### PR TITLE
Move the initialization parameter to constructors

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/ClusterConfiguration.java
+++ b/src/main/java/com/github/zk1931/jzab/ClusterConfiguration.java
@@ -20,9 +20,10 @@ package com.github.zk1931.jzab;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.Properties;
 import com.github.zk1931.jzab.proto.ZabMessage;
 import org.slf4j.Logger;
@@ -33,17 +34,17 @@ import org.slf4j.LoggerFactory;
  */
 class ClusterConfiguration implements Cloneable {
   private Zxid version;
-  private final List<String> peers;
+  private final Set<String> peers;
   private final String serverId;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ClusterConfiguration.class);
 
   public ClusterConfiguration(Zxid version,
-                              List<String> peers,
+                              Collection<String> peers,
                               String serverId) {
     this.version = version;
-    this.peers = new ArrayList<String>(peers);
+    this.peers = new HashSet<String>(peers);
     this.serverId = serverId;
   };
 
@@ -55,7 +56,7 @@ class ClusterConfiguration implements Cloneable {
     this.version = newVersion;
   }
 
-  public List<String> getPeers() {
+  public Set<String> getPeers() {
     return this.peers;
   }
 
@@ -76,9 +77,10 @@ class ClusterConfiguration implements Cloneable {
     StringBuilder strBuilder = new StringBuilder();
     String strVersion = this.version.toSimpleString();
     if (!this.peers.isEmpty()) {
-      strBuilder.append(this.peers.get(0));
-      for (int i = 1; i < this.peers.size(); ++i) {
-        strBuilder.append("," + this.peers.get(i));
+      String[] peersArray = this.peers.toArray(new String[this.peers.size()]);
+      strBuilder.append(peersArray[0]);
+      for (int i = 1; i < peersArray.length; ++i) {
+        strBuilder.append("," + peersArray[i]);
       }
     }
     prop.setProperty("peers", strBuilder.toString());
@@ -91,13 +93,13 @@ class ClusterConfiguration implements Cloneable {
     String strPeers = prop.getProperty("peers");
     Zxid version = Zxid.fromSimpleString(prop.getProperty("version"));
     String serverId = prop.getProperty("serverId");
-    List<String> peerList;
+    Set<String> peerSet;
     if (strPeers.equals("")) {
-      peerList = new ArrayList<String>();
+      peerSet = new HashSet<String>();
     } else {
-      peerList = new ArrayList<String>(Arrays.asList(strPeers.split(",")));
+      peerSet = new HashSet<String>(Arrays.asList(strPeers.split(",")));
     }
-    return new ClusterConfiguration(version, peerList, serverId);
+    return new ClusterConfiguration(version, peerSet, serverId);
   }
 
   public static
@@ -146,7 +148,6 @@ class ClusterConfiguration implements Cloneable {
   }
 
   public ClusterConfiguration clone() {
-    return new ClusterConfiguration(version, new ArrayList<String>(peers),
-                                    serverId);
+    return new ClusterConfiguration(version, peers, serverId);
   }
 }

--- a/src/main/java/com/github/zk1931/jzab/ZabConfig.java
+++ b/src/main/java/com/github/zk1931/jzab/ZabConfig.java
@@ -18,9 +18,6 @@
 
 package com.github.zk1931.jzab;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Configuration for Jzab.
  */
@@ -29,9 +26,6 @@ public class ZabConfig {
    * Maximum number of pending requests allowed for each server.
    */
   static final int MAX_PENDING_REQS = 5000;
-  private List<String> peers = new ArrayList<String>();
-  private String serverId = null;
-  private String joinPeer = null;
   private int timeoutMs = 1000;
   private int minSyncTimeoutMs = 3000;
   private long snapshotThresholdBytes = -1;
@@ -39,53 +33,6 @@ public class ZabConfig {
   private String logDir = System.getProperty("user.dir");
   private int maxBatchSize = 1000;
   private SslParameters sslParam = new SslParameters();
-
-  /**
-   * Gets the address of peers.
-   *
-   * @return a list of address(id) of other servers.
-   */
-  public List<String> getPeers() {
-    return peers;
-  }
-
-  /**
-   * Gets the id of itself.
-   *
-   * @return a string represents the id of itself
-   */
-  public String getServerId() {
-    return this.serverId;
-  }
-
-  /**
-   * Sets the id of itself.
-   *
-   * @param id the server id, the id a host:port string of the peer.
-   */
-  public void setServerId(String id) {
-    this.serverId = id;
-  }
-
-  /**
-   * Sets the servers in the cluster.
-   *
-   * @param servers the a list of servers.
-   */
-  public void setServers(String... servers) {
-    for (String peerId : servers) {
-      peers.add(peerId);
-    }
-  }
-
-  /**
-   * Gets the size of the ensemble.
-   *
-   * @return the number of the nodes in the ensemble.
-   */
-  public int getEnsembleSize() {
-    return getPeers().size();
-  }
 
   /**
    * Gets the directory for storing transaction log.
@@ -140,15 +87,6 @@ public class ZabConfig {
    */
   public void setMinSyncTimeoutMs(int timeout) {
     this.minSyncTimeoutMs = timeout;
-  }
-
-  /**
-   * Gets the address of peer you want to join in.
-   *
-   * @return the address of the peer.
-   */
-  public String getJoinPeer() {
-    return this.joinPeer;
   }
 
   /**

--- a/src/test/java/com/github/zk1931/jzab/FastLeaderElectionTest.java
+++ b/src/test/java/com/github/zk1931/jzab/FastLeaderElectionTest.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Tests for FastLeaderElection.
@@ -43,6 +45,10 @@ public class FastLeaderElectionTest extends TestBase {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     PersistentState state1 = makeInitialState(server1, 1);
     state1.setAckEpoch(0);
@@ -51,15 +57,10 @@ public class FastLeaderElectionTest extends TestBase {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitDiscovering();
     cb2.waitDiscovering();
@@ -82,6 +83,10 @@ public class FastLeaderElectionTest extends TestBase {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     PersistentState state1 = makeInitialState(server1, 1);
     state1.setProposedEpoch(1);
@@ -91,15 +96,10 @@ public class FastLeaderElectionTest extends TestBase {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitDiscovering();
     cb2.waitDiscovering();
@@ -122,20 +122,19 @@ public class FastLeaderElectionTest extends TestBase {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     PersistentState state1 = makeInitialState(server1, 1);
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitDiscovering();
     cb2.waitDiscovering();
@@ -163,6 +162,10 @@ public class FastLeaderElectionTest extends TestBase {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     PersistentState state1 = makeInitialState(server1, 0);
     state1.setAckEpoch(2);
@@ -177,20 +180,12 @@ public class FastLeaderElectionTest extends TestBase {
     state2.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
-    Zab zab3 = new Zab(st, config3, state3, cb3, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();

--- a/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
+++ b/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
@@ -134,10 +134,9 @@ public class SnapshotTest extends TestBase {
     ZabConfig config = new ZabConfig();
     // For testing purpose, set the threshold to 32 bytes..
     config.setSnapshotThreshold(32);
-    config.setServerId(server);
     config.setLogDir(getDirectory().getPath());
 
-    Zab zab = new Zab(st1, config, server);
+    Zab zab = new Zab(st1, config, server, server);
     st1.waitMemberChanged();
 
     for (int i = 0; i < nTxns; ++i) {
@@ -168,19 +167,17 @@ public class SnapshotTest extends TestBase {
     ZabConfig config1 = new ZabConfig();
     // For testing purpose, set the threshold to 32 bytes..
     config1.setSnapshotThreshold(32);
-    config1.setServerId(server1);
     config1.setLogDir(getDirectory().getPath() + File.separator + server1);
 
     ZabConfig config2 = new ZabConfig();
     // For testing purpose, set the threshold to 32 bytes..
     config2.setSnapshotThreshold(32);
-    config2.setServerId(server2);
     config2.setLogDir(getDirectory().getPath() + File.separator + server2);
 
-    Zab zab1 = new Zab(st1, config1, server1);
+    Zab zab1 = new Zab(st1, config1, server1, server1);
     st1.waitMemberChanged();
 
-    Zab zab2 = new Zab(st2, config2, server1);
+    Zab zab2 = new Zab(st2, config2, server2, server1);
     st2.waitMemberChanged();
 
     for (int i = 0; i < nTxns; ++i) {
@@ -228,14 +225,12 @@ public class SnapshotTest extends TestBase {
     // the threshold to 290 bytes. In this case, both the last zxid and snap
     // zxid will be (0, 50), which triggered the bug in old code.
     config1.setSnapshotThreshold(290);
-    config1.setServerId(server1);
     config1.setLogDir(getDirectory().getPath() + File.separator + server1);
 
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
     config2.setLogDir(getDirectory().getPath() + File.separator + server2);
 
-    Zab zab1 = new Zab(st1, config1, server1);
+    Zab zab1 = new Zab(st1, config1, server1, server1);
     st1.waitMemberChanged();
 
     for (int i = 0; i < nTxns; ++i) {
@@ -245,7 +240,7 @@ public class SnapshotTest extends TestBase {
     }
     st1.txnsCount.await();
     // Server2 joins in.
-    Zab zab2 = new Zab(st2, config2, server1);
+    Zab zab2 = new Zab(st2, config2, server2, server1);
     st2.waitMemberChanged();
     Assert.assertEquals(st1.state, st2.state);
     zab1.shutdown();

--- a/src/test/java/com/github/zk1931/jzab/ZabTest.java
+++ b/src/test/java/com/github/zk1931/jzab/ZabTest.java
@@ -24,7 +24,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
@@ -171,12 +173,12 @@ public class ZabTest extends TestBase  {
     TestStateMachine st = new TestStateMachine();
 
     String server1 = getUniqueHostPort();
-    ZabConfig config = new ZabConfig();
-    config.setServerId(server1);
-    config.setServers(server1);
-    PersistentState state = makeInitialState(server1, 10);
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
 
-    Zab zab1 = new Zab(st, config, state, cb, null);
+    ZabConfig config = new ZabConfig();
+    PersistentState state = makeInitialState(server1, 10);
+    Zab zab1 = new Zab(st, config, server1, peers, state, cb, null);
 
     cb.waitBroadcasting();
     Assert.assertEquals(0, cb.acknowledgedEpoch);
@@ -201,6 +203,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      * Case 1
@@ -222,15 +228,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -260,6 +261,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      * Case 2
@@ -281,15 +286,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -321,6 +321,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      * Case 3
@@ -342,15 +346,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -382,6 +381,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      * Case 4
@@ -405,15 +408,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(2);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -430,12 +428,12 @@ public class ZabTest extends TestBase  {
     zab2.shutdown();
   }
 
-  /**
-   * Test synchronization case 5.
-   *
-   * @throws InterruptedException
-   * @throws IOException in case of IO failure.
-   */
+ /**
+  * Test synchronization case 5.
+  *
+  * @throws InterruptedException
+  * @throws IOException in case of IO failure.
+  */
   @Test(timeout=20000)
   public void testSynchronizationCase5() throws Exception {
     QuorumTestCallback cb1 = new QuorumTestCallback();
@@ -445,38 +443,37 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
-     * Case 5
-     *
-     * Before Synchronization.
-     *
-     *  L : <0, 0>  <0, 1>                (f.a = 0)
-     *  F : <0, 0>,         <1,0>         (f.a = 1)
-     *
-     * Expected history of Leader and Follower after synchronization:
-     *
-     * <0, 0>, <1, 0>
-     */
+    * Case 5
+    *
+    * Before Synchronization.
+    *
+    *  L : <0, 0>  <0, 1>                (f.a = 0)
+    *  F : <0, 0>,         <1,0>         (f.a = 1)
+    *
+    * Expected history of Leader and Follower after synchronization:
+    *
+    * <0, 0>, <1, 0>
+    */
 
     PersistentState state1 = makeInitialState(server1, 2);
     state1.setAckEpoch(0);
 
     PersistentState state2 = makeInitialState(server2, 1);
     state2.log.append(new Transaction(new Zxid(1, 0),
-                                      ByteBuffer.wrap("1,0".getBytes())));
+                                     ByteBuffer.wrap("1,0".getBytes())));
     state2.setAckEpoch(1);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -508,6 +505,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      * Case 6
@@ -529,15 +530,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -573,6 +569,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     PersistentState state1 = makeInitialState(server1, 3);
     state1.setAckEpoch(0);
@@ -581,15 +581,10 @@ public class ZabTest extends TestBase  {
     state2.setAckEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st, config2, state2, cb2, null);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -615,6 +610,10 @@ public class ZabTest extends TestBase  {
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
     String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     // Expecting 5 delivered transactions.
     TestStateMachine st1 = new TestStateMachine(5);
@@ -648,20 +647,12 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(1);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
-    Zab zab1 = new Zab(st1, config1, state1, cb1, null);
-    Zab zab2 = new Zab(st2, config2, state2, cb2, null);
-    Zab zab3 = new Zab(st3, config3, state3, cb3, null);
+    Zab zab1 = new Zab(st1, config1, server1, peers, state1, cb1, null);
+    Zab zab2 = new Zab(st2, config2, server2, peers, state2, cb2, null);
+    Zab zab3 = new Zab(st3, config3, server3, peers, state3, cb3, null);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -700,6 +691,10 @@ public class ZabTest extends TestBase  {
     final String server1 = getUniqueHostPort();
     final String server2 = getUniqueHostPort();
     final String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      *  This test simulates that server1 will be crashed after first round
@@ -729,16 +724,8 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     FailureCaseCallback fcb = new FailureCaseCallback() {
       boolean crashed = false;
@@ -758,9 +745,9 @@ public class ZabTest extends TestBase  {
       }
     };
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, fcb);
-    Zab zab2 = new Zab(st, config2, state2, cb2, fcb);
-    Zab zab3 = new Zab(st, config3, state3, cb3, fcb);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, fcb);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, fcb);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, fcb);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -791,6 +778,10 @@ public class ZabTest extends TestBase  {
     final String server1 = getUniqueHostPort();
     final String server2 = getUniqueHostPort();
     final String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      *  This test simulates that 2 followers will crash after
@@ -820,16 +811,8 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     FailureCaseCallback fcb = new FailureCaseCallback() {
       volatile int crashedCount = 0;
@@ -849,9 +832,9 @@ public class ZabTest extends TestBase  {
       }
     };
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, fcb);
-    Zab zab2 = new Zab(st, config2, state2, cb2, fcb);
-    Zab zab3 = new Zab(st, config3, state3, cb3, fcb);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, fcb);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, fcb);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, fcb);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -882,6 +865,10 @@ public class ZabTest extends TestBase  {
     final String server1 = getUniqueHostPort();
     final String server2 = getUniqueHostPort();
     final String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      *  This test simulates that the first leader will be crashed after the
@@ -910,16 +897,8 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     FailureCaseCallback fcb = new FailureCaseCallback() {
       boolean crashed = false;
@@ -939,9 +918,9 @@ public class ZabTest extends TestBase  {
       }
     };
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, fcb);
-    Zab zab2 = new Zab(st, config2, state2, cb2, fcb);
-    Zab zab3 = new Zab(st, config3, state3, cb3, fcb);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, fcb);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, fcb);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, fcb);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -972,6 +951,10 @@ public class ZabTest extends TestBase  {
     final String server1 = getUniqueHostPort();
     final String server2 = getUniqueHostPort();
     final String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      *  This test simulates that two followers will be crash once they
@@ -1001,16 +984,8 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     FailureCaseCallback fcb = new FailureCaseCallback() {
       volatile int crashCount = 0;
@@ -1030,9 +1005,9 @@ public class ZabTest extends TestBase  {
       }
     };
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, fcb);
-    Zab zab2 = new Zab(st, config2, state2, cb2, fcb);
-    Zab zab3 = new Zab(st, config3, state3, cb3, fcb);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, fcb);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, fcb);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, fcb);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -1063,6 +1038,10 @@ public class ZabTest extends TestBase  {
     final String server1 = getUniqueHostPort();
     final String server2 = getUniqueHostPort();
     final String server3 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
+    peers.add(server3);
 
     /*
      *  This test simulates that the first leader will be crashed after the
@@ -1091,16 +1070,8 @@ public class ZabTest extends TestBase  {
     state3.setProposedEpoch(0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     FailureCaseCallback fcb = new FailureCaseCallback() {
       boolean crashed = false;
@@ -1120,9 +1091,9 @@ public class ZabTest extends TestBase  {
       }
     };
 
-    Zab zab1 = new Zab(st, config1, state1, cb1, fcb);
-    Zab zab2 = new Zab(st, config2, state2, cb2, fcb);
-    Zab zab3 = new Zab(st, config3, state3, cb3, fcb);
+    Zab zab1 = new Zab(st, config1, server1, peers, state1, cb1, fcb);
+    Zab zab2 = new Zab(st, config2, server2, peers, state2, cb2, fcb);
+    Zab zab3 = new Zab(st, config3, server3, peers, state3, cb3, fcb);
 
     cb1.waitBroadcasting();
     cb2.waitBroadcasting();
@@ -1193,16 +1164,8 @@ public class ZabTest extends TestBase  {
     state3.setLastSeenConfig(cnf3);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     Zab zab1 = new Zab(st, config1, state1, cb1, null);
     Zab zab2 = new Zab(st, config2, state2, cb2, null);
@@ -1281,16 +1244,8 @@ public class ZabTest extends TestBase  {
     state3.setLastSeenConfig(cnf3);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     Zab zab1 = new Zab(st, config1, state1, cb1, null);
     Zab zab2 = new Zab(st, config2, state2, cb2, null);
@@ -1373,16 +1328,8 @@ public class ZabTest extends TestBase  {
     state3.setLastSeenConfig(cnf3);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2, server3);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-    config2.setServers(server1, server2, server3);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
-    config3.setServers(server1, server2, server3);
 
     Zab zab1 = new Zab(st, config1, state1, cb1, null);
     Zab zab2 = new Zab(st, config2, state2, cb2, null);
@@ -1434,21 +1381,16 @@ public class ZabTest extends TestBase  {
     PersistentState state3 = makeInitialState(server3, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb1.waitCopCommit();
 
-    Zab zab3 = new Zab(st3, config3, server1, state3, cb3, null);
+    Zab zab3 = new Zab(st3, config3, server3, server1, state3, cb3, null);
     cb1.waitCopCommit();
 
     zab1.send(ByteBuffer.wrap("req1".getBytes()));
@@ -1492,23 +1434,18 @@ public class ZabTest extends TestBase  {
     PersistentState state3 = makeInitialState(server3, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
     zab1.send(ByteBuffer.wrap("req1".getBytes()));
     zab1.send(ByteBuffer.wrap("req2".getBytes()));
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb1.waitCopCommit();
 
-    Zab zab3 = new Zab(st3, config3, server1, state3, cb3, null);
+    Zab zab3 = new Zab(st3, config3, server3, server1, state3, cb3, null);
     cb1.waitCopCommit();
     cb3.waitBroadcasting();
 
@@ -1527,8 +1464,8 @@ public class ZabTest extends TestBase  {
   @Test(timeout=20000)
   public void testJoinCase3() throws Exception {
     /*
-     * This test case shows that after reconfiguration is done, the quorum size
-     * should be changed.
+     * This test case shows that after reconfiguration is done, the quorum
+     * size should be changed.
      *
      * Case 3 :
      *
@@ -1552,16 +1489,13 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
     zab1.send(ByteBuffer.wrap("req1".getBytes()));
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
     st2.txnsCount.await();
 
@@ -1608,15 +1542,12 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
 
     zab1.send(ByteBuffer.wrap("req1".getBytes()));
@@ -1653,15 +1584,12 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
 
     // serve2 removes server1.
@@ -1689,12 +1617,9 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     // Waits for clusterChange and leading callback.
     st1.waitMembershipChanged();
     // Make sure first config contains itself.
@@ -1702,7 +1627,7 @@ public class ZabTest extends TestBase  {
     // The cluster size should be 1.
     Assert.assertEquals(1, st1.clusters.size());
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     st2.waitMembershipChanged();
     // Make sure first config contains itself.
     Assert.assertTrue(st2.clusters.contains(server1));
@@ -1734,15 +1659,12 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
     // Server2 gona join in.
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
 
     // While server2 is joining, we start sending 100 requests.
     for (int i = 0; i < 100; ++i) {
@@ -1774,18 +1696,15 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
     // Send first request.
     zab1.send(ByteBuffer.wrap("txn".getBytes()));
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
     // Server2 removes itself from cluster.
     zab2.remove(server2);
@@ -1828,22 +1747,17 @@ public class ZabTest extends TestBase  {
     PersistentState state3 = makeInitialState(server3, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
     st2.waitMembershipChanged();
 
-    Zab zab3 = new Zab(st3, config3, server1, state3, cb3, null);
+    Zab zab3 = new Zab(st3, config3, server3, server1, state3, cb3, null);
     cb3.waitBroadcasting();
     st3.waitMembershipChanged();
 
@@ -1874,9 +1788,8 @@ public class ZabTest extends TestBase  {
 
     PersistentState state1 = makeInitialState(server1, 0);
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
     zab1.send(ByteBuffer.wrap("req1".getBytes()));
@@ -1906,15 +1819,10 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
-    cb1.waitBroadcasting();
-
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
 
     zab2.send(ByteBuffer.wrap("req1".getBytes()));
@@ -1963,17 +1871,14 @@ public class ZabTest extends TestBase  {
     PersistentState state2 = makeInitialState(server2, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server1, server1, state2, cb2, null);
 
     // Waits for a while to make zab2 first joining fails.
     Thread.sleep(500);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server2, server1, state1, cb1, null);
     // Finally the joiner will join the cluster.
     cb2.waitBroadcasting();
     zab1.shutdown();
@@ -2009,21 +1914,16 @@ public class ZabTest extends TestBase  {
     PersistentState state3 = makeInitialState(server3, 0);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-
     ZabConfig config2 = new ZabConfig();
-    config2.setServerId(server2);
-
     ZabConfig config3 = new ZabConfig();
-    config3.setServerId(server3);
 
-    Zab zab1 = new Zab(st1, config1, server1, state1, cb1, null);
+    Zab zab1 = new Zab(st1, config1, server1, server1, state1, cb1, null);
     cb1.waitBroadcasting();
 
-    Zab zab2 = new Zab(st2, config2, server1, state2, cb2, null);
+    Zab zab2 = new Zab(st2, config2, server2, server1, state2, cb2, null);
     cb2.waitBroadcasting();
 
-    Zab zab3 = new Zab(st3, config3, server1, state3, cb3, null);
+    Zab zab3 = new Zab(st3, config3, server3, server1, state3, cb3, null);
     cb3.waitBroadcasting();
 
     // Simulates zab3 failures.
@@ -2046,13 +1946,13 @@ public class ZabTest extends TestBase  {
     TestStateMachine st = new TestStateMachine();
     String server1 = getUniqueHostPort();
     String server2 = getUniqueHostPort();
+    Set<String> peers = new HashSet<>();
+    peers.add(server1);
+    peers.add(server2);
 
     ZabConfig config1 = new ZabConfig();
-    config1.setServerId(server1);
-    config1.setServers(server1, server2);
     config1.setLogDir(new File(getDirectory(), server1).getPath());
-
-    Zab zab1 = new Zab(st, config1);
+    Zab zab1 = new Zab(st, config1, server1, peers);
 
     zab1.send(ByteBuffer.wrap("HelloWorld".getBytes()));
     zab1.shutdown();


### PR DESCRIPTION
As we discussed, for different initialization ways (join / static config / recover from log) we have different constructors.
