### PR TITLE
Associate a context with request

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/Follower.java
+++ b/src/main/java/com/github/zk1931/jzab/Follower.java
@@ -140,7 +140,7 @@ public class Follower extends Participant {
       }
     } else if (phase == Phase.FINALIZING) {
       MDC.put("phase", "finalizing");
-      this.stateMachine.recovering();
+      stateMachine.recovering(pendings);
       if (persistence.isInStateTransfer()) {
         // If the participant goes back to recovering phase in state
         // trasferring mode, we need to explicitly undo the state transferring.
@@ -416,7 +416,7 @@ public class Follower extends Participant {
     CommitProcessor commitProcessor
       = new CommitProcessor(stateMachine, lastDeliveredZxid, serverId,
                             transport, null, clusterConfig, electedLeader,
-                            pendingReqs);
+                            pendings);
     SnapshotProcessor snapProcessor =
       new SnapshotProcessor(stateMachine, persistence, serverId, transport);
     // The last time of HEARTBEAT message comes from leader.

--- a/src/main/java/com/github/zk1931/jzab/Leader.java
+++ b/src/main/java/com/github/zk1931/jzab/Leader.java
@@ -187,7 +187,7 @@ public class Leader extends Participant {
       }
     } else if (phase == Phase.FINALIZING) {
       MDC.put("phase", "finalizing");
-      this.stateMachine.recovering();
+      stateMachine.recovering(pendings);
       if (persistence.isInStateTransfer()) {
         // If the participant goes back to recovering phase in state
         // transferring mode, we need to explicitly undo the state transferring.
@@ -609,7 +609,7 @@ public class Leader extends Participant {
     CommitProcessor commitProcessor =
         new CommitProcessor(stateMachine, lastDeliveredZxid, serverId,
                             transport, quorumMap.keySet(),
-                            clusterConfig, electedLeader, pendingReqs);
+                            clusterConfig, electedLeader, pendings);
     SnapshotProcessor snapProcessor =
       new SnapshotProcessor(stateMachine, persistence, serverId, transport);
     // First time notifies the client active members and cluster configuration.

--- a/src/main/java/com/github/zk1931/jzab/PendingRequests.java
+++ b/src/main/java/com/github/zk1931/jzab/PendingRequests.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the zk1931 under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.zk1931.jzab;
+
+import java.util.List;
+import java.util.LinkedList;
+
+/**
+ * Stores different kinds of pending requests.
+ */
+public class PendingRequests {
+  /**
+   * The pending send requests.
+   * The first element of the tuple is the request sent, the second element is
+   * the corresponding context
+   */
+  public final List<Tuple> pendingSends= new LinkedList<>();
+
+  /**
+   * The pending flush requests.
+   * The first element of the tuple is flush request, the second element is ctx.
+   */
+  public final List<Tuple> pendingFlushes = new LinkedList<>();
+
+  /**
+   * The pending remove requests.
+   * The first element of tuple is serverId, the second element is ctx.
+   */
+  public final List<Tuple> pendingRemoves = new LinkedList<>();
+
+  /**
+   * The pending snapshot requests.
+   */
+  public final List<Object> pendingSnapshots = new LinkedList<>();
+
+  /**
+   * The tuple holds both request and ctx.
+   */
+  public static class Tuple {
+    public final Object param;
+    public final Object ctx;
+
+    public Tuple(Object param, Object ctx) {
+      this.param = param;
+      this.ctx = ctx;
+    }
+  }
+}

--- a/src/main/java/com/github/zk1931/jzab/PreProcessor.java
+++ b/src/main/java/com/github/zk1931/jzab/PreProcessor.java
@@ -130,18 +130,19 @@ public class PreProcessor implements RequestProcessor,
           addToQuorumSet(source);
         } else if (msg.getType() == MessageType.REMOVE) {
           String peerId = msg.getRemove().getServerId();
+          String clientId = request.getServerId();
           LOG.debug("Got REMOVE for {}.", peerId);
           this.clusterConfig.removePeer(peerId);
           this.clusterConfig.setVersion(zxid);
           ByteBuffer cop = this.clusterConfig.toByteBuffer();
           Transaction txn = new Transaction(zxid, ProposalType.COP_VALUE, cop);
-          Message prop = MessageBuilder.buildProposal(txn);
+          Message prop = MessageBuilder.buildProposal(txn, clientId);
           // Broadcasts COP.
           for (PeerHandler ph : quorumMap.values()) {
             ph.queueMessage(prop);
           }
           // Removes it from quorum set.
-          removeFromQuorumSet(msg.getDisconnected().getServerId());
+          removeFromQuorumSet(peerId);
         } else if (msg.getType() == MessageType.DISCONNECTED) {
           String peerId = msg.getDisconnected().getServerId();
           LOG.debug("Got DISCONNECTED from {}.", peerId);

--- a/src/test/java/com/github/zk1931/jzab/TestStateMachine.java
+++ b/src/test/java/com/github/zk1931/jzab/TestStateMachine.java
@@ -60,7 +60,8 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void deliver(Zxid zxid, ByteBuffer stateUpdate, String clientId) {
+  public void deliver(Zxid zxid, ByteBuffer stateUpdate, String clientId,
+                      Object ctx) {
     // Add the delivered message to list.
     LOG.debug("Delivers txn {}. Origin : {}", zxid, clientId);
     this.deliveredTxns.add(new Transaction(zxid, stateUpdate));
@@ -70,12 +71,16 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void flushed(ByteBuffer flushReq) {
+  public void flushed(ByteBuffer flushReq, Object ctx) {
     LOG.debug("Deliver syncReq {}.");
     this.deliveredTxns.add(new Transaction(Zxid.ZXID_NOT_EXIST, flushReq));
     if (txnsCount != null) {
       txnsCount.countDown();
     }
+  }
+
+  @Override
+  public void removed(String serverId, Object ctx) {
   }
 
   @Override
@@ -85,7 +90,7 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void snapshotDone(String filePath) {
+  public void snapshotDone(String filePath, Object ctx) {
   }
 
   @Override
@@ -95,8 +100,7 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void recovering() {
-  }
+  public void recovering(PendingRequests pendings) {}
 
   @Override
   public void leading(Set<String> followers, Set<String> clusterMembers) {


### PR DESCRIPTION
Since all requests issued to Jzab is asynchronous, we need a way to match the completed requests in callback with the one we issued. 

Associating a context object with each requests seems to be a good way to solve this, like what ZooKeeper does.

```
void send(ByteBuffer req, Object ctx);
void flush(ByteBuffer req, Object ctx);
void remove(String serverId, Object ctx);
```
