### PR TITLE
Some refactoring on code.

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/PreProcessor.java
+++ b/src/main/java/com/github/zk1931/jzab/PreProcessor.java
@@ -63,7 +63,7 @@ public class PreProcessor implements RequestProcessor,
     this.stateMachine = stateMachine;
     this.quorumMapOriginal = quorumMap;
     this.quorumMap = new HashMap<String, PeerHandler>(quorumMap);
-    this.clusterConfig = config;
+    this.clusterConfig = config.clone();
     ExecutorService es =
         Executors.newSingleThreadExecutor(DaemonThreadFactory.FACTORY);
     ft = es.submit(this);


### PR DESCRIPTION
1. Make all the processors as member variables instead of local variable.
2. Make clusterConfig as member variable instead of local variable.

Now the code looks shorter since we don't need to pass processors
around.
