### PR TITLE
Bug about synchronization.

### DIFF
--- a/src/test/java/com/github/zk1931/jzab/PersistentStateTest.java
+++ b/src/test/java/com/github/zk1931/jzab/PersistentStateTest.java
@@ -208,4 +208,30 @@ public class PersistentStateTest extends TestBase {
     Assert.assertEquals(persistence.getLastSeenConfig().getVersion(),
                         new Zxid(0, 2));
   }
+
+  @Test
+  public void testLastConfig() throws IOException {
+    PersistentState persistence = new PersistentState(getDirectory());
+    Set<String> peers = new HashSet<String>();
+    ClusterConfiguration cnf =
+      new ClusterConfiguration(new Zxid(0, 1), peers, "");
+    // Initialy set version to <0, 1>
+    persistence.setLastSeenConfig(cnf);
+
+    cnf = persistence.getLastConfigWithin(new Zxid(0, 1));
+    // Now the last config within <0, 1> should be <0, 1>
+    Assert.assertEquals(new Zxid(0, 1), cnf.getVersion());
+
+    cnf = new ClusterConfiguration(new Zxid(0, 2), peers, "");
+    persistence.setLastSeenConfig(cnf);
+    // Now the last config within <0, 2> should be <0, 2>
+    cnf = persistence.getLastConfigWithin(new Zxid(0, 2));
+    Assert.assertEquals(new Zxid(0, 2), cnf.getVersion());
+    cnf = persistence.getLastConfigWithin(new Zxid(0, 1));
+    // Now the last config within <0, 1> should be <0, 1>
+    Assert.assertEquals(new Zxid(0, 1), cnf.getVersion());
+
+    cnf = persistence.getLastConfigWithin(new Zxid(0, 0));
+    Assert.assertTrue(cnf == null);
+  }
 }


### PR DESCRIPTION
I found this bug in pulsed integration test of multiple servers.

I'll try to explain the bug here : 

First we have two phase synchronizations, the first message from follower is SYNC_HISTORY and the second message is JOIN.  For each message we'll construct SyncPeerTask and pass the last sync zxid and last seen configuration. And the invariant is that the last seen configuration is always <= last sync zxid because at the end of synchronization the follower will cleanup all the configuration files which  > last zxid in log and in cleanup function we've sanity check if there's no configuration files after cleaning up then raises an exception.

And during the test this exception has been raise occasionally. I logged the out put and found the reason. Because the invariant  

> the last seen configuration is always <= last sync zxid 

is violated. The reason is tricky, the leader maintains the lastAck zxid, this is not necessarily most updated, and when it receives SYNC_HISTORY message it will construct and launch the SyncPeerTask with `last synced  zxid = lastAck && last seen config = persistence.getLastSeenConfig`,  every time the SyncProposalProcessor of leader fsyncs the data to disk it will also put the message in queue of leader so it can update lastAck field. And at this time if another follower is during joining process it's possible that the leader fsynced the COP to log but before the lastAck gets updated it receives SYNC_HISTORY, in this case the invariant `the last seen configuration is always <= last sync zxid` will be violated.

This bug should be not hard to fix and I'll add a patch today.
