### PR TITLE
Code refactoring on the logic of taking message from queue.

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/ElectionMessageFilter.java
+++ b/src/main/java/com/github/zk1931/jzab/ElectionMessageFilter.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the zk1931 under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.zk1931.jzab;
+
+import com.github.zk1931.jzab.proto.ZabMessage.Message.MessageType;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * ElectionMessageFilter is a filter class which acts as a successor of
+ * MessageQueueFilter. It handles and filters ELECTION_INFO message, which will
+ * be passed to its Election object.
+ */
+class ElectionMessageFilter extends MessageQueueFilter {
+  private final Election election;
+
+  ElectionMessageFilter(BlockingQueue<MessageTuple> messageQueue,
+                        Election election) {
+    super(messageQueue);
+    this.election = election;
+  }
+
+  @Override
+  protected MessageTuple getMessage(int timeoutMs)
+      throws InterruptedException, TimeoutException {
+    int startMs = (int)(System.nanoTime() / 1000000);
+    while (true) {
+      int nowMs = (int)(System.nanoTime() / 1000000);
+      int remainMs = timeoutMs - (nowMs - startMs);
+      if (remainMs < 0) {
+        remainMs = 0;
+      }
+      MessageTuple tuple = super.getMessage(remainMs);
+      if (tuple.getMessage().getType() == MessageType.ELECTION_INFO) {
+        this.election.reply(tuple);
+      } else {
+        return tuple;
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/zk1931/jzab/MessageQueueFilter.java
+++ b/src/main/java/com/github/zk1931/jzab/MessageQueueFilter.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the zk1931 under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.zk1931.jzab;
+
+import com.github.zk1931.jzab.Participant.LeftCluster;
+import com.github.zk1931.jzab.proto.ZabMessage.Message.MessageType;
+import com.google.protobuf.TextFormat;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MessageQueueFilter is a filter class, filter classes filter and handle the
+ * specific messages they are interested in.
+ * This is the most basic filter class, it only acts as the base class for other
+ * filters. It only filters and handles SHUT_DOWN message, which is the
+ * message for shutting down Jzab. For this message it simply throws a
+ * LeftCluster exception.
+ */
+class MessageQueueFilter {
+
+  private final BlockingQueue<MessageTuple> messageQueue;
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(MessageQueueFilter.class);
+
+  MessageQueueFilter(BlockingQueue<MessageTuple> messageQueue) {
+    this.messageQueue = messageQueue;
+  }
+
+  /**
+   * Takes the filtered message from message queue. This method will be blocked
+   * until the message becomes available or timeout is detected.
+   *
+   * @param timeoutMs the timeout for blocking, in millisecond.
+   * @return filtered message tuple.
+   * @throws InterruptedException in case of interrupt on blocking.
+   * @throws TimeoutException if timeout happens during blocking.
+   */
+  protected MessageTuple getMessage(int timeoutMs)
+      throws InterruptedException, TimeoutException {
+    MessageTuple tuple = messageQueue.poll(timeoutMs,
+                                           TimeUnit.MILLISECONDS);
+    if (tuple == null) {
+      throw new TimeoutException("Timeout while waiting for the message.");
+    }
+    if (tuple.getMessage().getType() == MessageType.SHUT_DOWN) {
+      // If it's SHUT_DOWN message.
+      throw new LeftCluster("Left cluster");
+    }
+    return tuple;
+  }
+
+  /**
+   * Takes the expected message from message queue. This method will be blocked
+   * until the expected message from the expected source becomes
+   * available or timeout is detected.
+   *
+   * @param type the expected message type.
+   * @param source the expected source of the message, or null if the source
+   * doesn't matter.
+   * @param timeoutMs the timeout for blocking, in millisecond.
+   * @return filtered message tuple.
+   * @throws InterruptedException in case of interrupt on blocking.
+   * @throws TimeoutException if timeout happens during blocking.
+   */
+  protected MessageTuple getExpectedMessage(MessageType type,
+                                            String source,
+                                            int timeoutMs)
+      throws TimeoutException, InterruptedException {
+    int startTime = (int) (System.nanoTime() / 1000000);
+    // Waits until the expected message is received.
+    while (true) {
+      MessageTuple tuple = getMessage(timeoutMs);
+      String from = tuple.getServerId();
+      if (tuple.getMessage().getType() == type &&
+          (source == null || source.equals(from))) {
+        // Return message only if it's expected type and expected source.
+        return tuple;
+      } else {
+        int curTime = (int) (System.nanoTime() / 1000000);
+        if (curTime - startTime >= timeoutMs) {
+          throw new TimeoutException("Timeout in getExpectedMessage.");
+        }
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Got an unexpected message from {}: {}",
+                    tuple.getServerId(),
+                    TextFormat.shortDebugString(tuple.getMessage()));
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/zk1931/jzab/MessageTuple.java
+++ b/src/main/java/com/github/zk1931/jzab/MessageTuple.java
@@ -30,7 +30,6 @@ class MessageTuple {
 
   public static final MessageTuple REQUEST_OF_DEATH =
       new MessageTuple(null, null);
-  public static final MessageTuple GO_BACK = new MessageTuple(null, null);
 
   public MessageTuple(String serverId, Message message) {
     this(serverId, message, null);


### PR DESCRIPTION
The logic of taking message from message queue was messy. For example,
the leader and follower need to filter and process certain messages in
getMessage method, and so does FastLeaderElection. This results in
duplicate code and makes the intention of the code unclear(code needs to
deal with different kinds of messages just in one method). Refactoring
the code so that we have different kinds of message filters and each
filter filters and processes certain types of messages. This makes the
logic clearer and code reuse better.