### PR TITLE
adding zxid to flush() method of state machine

### DIFF
--- a/src/main/java/com/github/zk1931/jzab/CommitProcessor.java
+++ b/src/main/java/com/github/zk1931/jzab/CommitProcessor.java
@@ -293,7 +293,7 @@ class CommitProcessor implements RequestProcessor, Callable<Void> {
                 + "pendingFlushes.");
           }
           Object ctx = tp.ctx;
-          stateMachine.flushed(flush.getBody(), ctx);
+          stateMachine.flushed(flush.getWaitZxid(), flush.getBody(), ctx);
           flushQueue.remove();
         } else {
           break;

--- a/src/main/java/com/github/zk1931/jzab/StateMachine.java
+++ b/src/main/java/com/github/zk1931/jzab/StateMachine.java
@@ -60,7 +60,7 @@ public interface StateMachine {
    * @param  flushRequest the flush request.
    * @param ctx the context object.
    */
-  void flushed(ByteBuffer flushRequest, Object ctx);
+  void flushed(Zxid zxid, ByteBuffer flushRequest, Object ctx);
 
   /**
    * Callback for {@link Zab#takeSnapshot}.

--- a/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
+++ b/src/test/java/com/github/zk1931/jzab/SnapshotTest.java
@@ -71,7 +71,7 @@ class SnapshotStateMachine implements StateMachine {
   }
 
   @Override
-  public void flushed(ByteBuffer flushReq, Object ctx) {}
+  public void flushed(Zxid zxid, ByteBuffer flushReq, Object ctx) {}
 
   @Override
   public void save(FileOutputStream fos) {

--- a/src/test/java/com/github/zk1931/jzab/TestStateMachine.java
+++ b/src/test/java/com/github/zk1931/jzab/TestStateMachine.java
@@ -71,9 +71,9 @@ class TestStateMachine implements StateMachine {
   }
 
   @Override
-  public void flushed(ByteBuffer flushReq, Object ctx) {
+  public void flushed(Zxid zxid, ByteBuffer flushReq, Object ctx) {
     LOG.debug("Deliver syncReq {}.");
-    this.deliveredTxns.add(new Transaction(Zxid.ZXID_NOT_EXIST, flushReq));
+    this.deliveredTxns.add(new Transaction(zxid, flushReq));
     if (txnsCount != null) {
       txnsCount.countDown();
     }

--- a/src/test/java/com/github/zk1931/jzab/ZabTest.java
+++ b/src/test/java/com/github/zk1931/jzab/ZabTest.java
@@ -1983,9 +1983,9 @@ public class ZabTest extends TestBase  {
       }
 
       @Override
-      public void flushed(ByteBuffer flushReq, Object ctx) {
+      public void flushed(Zxid zxid, ByteBuffer flushReq, Object ctx) {
         flushCtxs.add(ctx);
-        super.flushed(flushReq, ctx);
+        super.flushed(zxid, flushReq, ctx);
       }
 
       @Override


### PR DESCRIPTION
Investigating jzab found that there is no zxid in flush() method of state machine.
Could you say why it so? Was there some idea behind that?
Generally it seems just missed and adding it back works well.
Did I missed something?